### PR TITLE
ci: migrate to self-hosted runner + fix README badge owner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: CodeQL
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   auto-merge:
     name: Auto-Merge
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Approve PR

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   yaml-lint:
     name: YAML Lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,7 +30,7 @@ jobs:
 
   markdown-lint:
     name: Markdown Lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Turing RK1 Kubernetes Cluster
 
-[![GitHub Release](https://img.shields.io/github/v/release/jfreed-dev/turing-rk1-cluster)](https://github.com/jfreed-dev/turing-rk1-cluster/releases)
-[![Lint](https://github.com/jfreed-dev/turing-rk1-cluster/actions/workflows/lint.yml/badge.svg)](https://github.com/jfreed-dev/turing-rk1-cluster/actions/workflows/lint.yml)
-[![CodeQL](https://github.com/jfreed-dev/turing-rk1-cluster/actions/workflows/codeql.yml/badge.svg)](https://github.com/jfreed-dev/turing-rk1-cluster/actions/workflows/codeql.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/freed-dev-llc/turing-rk1-cluster)](https://github.com/freed-dev-llc/turing-rk1-cluster/releases)
+[![Lint](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/lint.yml/badge.svg)](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/lint.yml)
+[![CodeQL](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/codeql.yml/badge.svg)](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Talos](https://img.shields.io/badge/Talos-v1.11.6-blue)](https://www.talos.dev/)
 [![K3s](https://img.shields.io/badge/K3s-v1.31-FFC61C)](https://k3s.io/)


### PR DESCRIPTION
## Summary
- Migrates 3 workflows (4 jobs) from `ubuntu-latest` → `self-hosted` (Cerebrum runner). Cuts cloud-billed minutes for CodeQL, dependabot-auto-merge, lint.
- Fixes README badge URLs — they still pointed at `jfreed-dev/` after the repo moved to the org.

## Jobs migrated
- `codeql.yml` `analyze` — CodeQL JS action, native on macOS-arm64
- `dependabot-auto-merge.yml` `auto-merge` — gh CLI only
- `lint.yml` `yaml-lint` (yamllint pip) + `markdown-lint` (markdownlint-cli2 JS)

## Out of scope (intentionally not flipped)
None — every workflow in this repo qualified as safe.

## Rollback
Reverting this commit restores `ubuntu-latest` for all flipped jobs. No state migration; the workflows are stateless.

## Test plan
- [ ] CI runs green on this PR (validates the runner accepts the workflows)
- [ ] Spot-check Actions tab shows jobs landing on `self-hosted` after merge