### PR TITLE
ci(codeql): switch back to ubuntu-latest (arm64 unsupported)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: CodeQL
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
CodeQL CLI has no linux/arm64 build; the Spark self-hosted runner is arm64 and fails at `Initialize CodeQL` with `Exec format error`. Since CodeQL is a required status check, this also blocks all PRs (PR #18 has been stuck 7 days).