### PR TITLE
docs(architecture): force mermaid neutral theme for contrast in both light/dark mode

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,6 +5,7 @@ This document provides visual architecture diagrams for the Turing RK1 Kubernete
 ## High-Level Overview
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 flowchart TB
     subgraph External["External Network (10.10.88.0/24)"]
         Client[Client Workstation]
@@ -50,6 +51,7 @@ flowchart TB
 ## Kubernetes Architecture
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 flowchart TB
     subgraph ControlPlane["Control Plane (Node 1)"]
         API["kube-apiserver<br/>:6443"]
@@ -105,6 +107,7 @@ flowchart TB
 ## Storage Architecture
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 flowchart TB
     subgraph StorageLayer["Longhorn Distributed Storage"]
         LM["Longhorn Manager"]
@@ -160,6 +163,7 @@ flowchart TB
 ## Network Traffic Flow
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 flowchart LR
     subgraph External["External"]
         User["User<br/>Browser/CLI"]
@@ -199,6 +203,7 @@ flowchart LR
 ## Monitoring Stack
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 flowchart TB
     subgraph Targets["Scrape Targets"]
         NodeExp["Node Exporter<br/>(per node)"]
@@ -237,6 +242,7 @@ flowchart TB
 ## Component Namespaces
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 flowchart TB
     subgraph kubesystem["kube-system namespace"]
         CoreDNS["coredns"]
@@ -280,6 +286,7 @@ flowchart TB
 ## Hardware Specifications
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 flowchart TB
     subgraph RK1["Turing RK1 Module (x4)"]
         subgraph SoC["Rockchip RK3588"]
@@ -333,6 +340,7 @@ flowchart TB
 ## Data Flow Example: Web Request
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 sequenceDiagram
     participant User
     participant DNS
@@ -357,6 +365,7 @@ sequenceDiagram
 ## Deployment Dependencies
 
 ```mermaid
+%%{init: {'theme': 'neutral'}}%%
 flowchart TD
     Talos["Talos Linux<br/>(Base OS)"] --> K8s["Kubernetes<br/>(Orchestration)"]
     K8s --> CoreDNS["CoreDNS"]


### PR DESCRIPTION
## Summary
- Adds `%%{init: {'theme': 'neutral'}}%%` to each of the 9 mermaid diagrams in `docs/ARCHITECTURE.md`.
- Docs-only change — 9 lines added, no removals.

## Why
The default mermaid theme renders with very low contrast in GitHub's dark mode (faint subgraph backgrounds, washed-out edge labels). The `neutral` (grayscale) theme keeps the diagrams legible in both light and dark mode without needing per-node styling.

Mirrors the same change applied to `turing-ansible-cluster/docs/ARCHITECTURE.md` ([PR #8](https://github.com/freed-dev-llc/turing-ansible-cluster/pull/8)).

## Test plan
- [x] Open `docs/ARCHITECTURE.md` on GitHub in light mode — diagrams render with crisp grayscale
- [x] Toggle to dark mode — diagrams still readable, no light-on-light text
- [x] All 9 diagrams render successfully (no parse error from the init directive)