### PR TITLE
docs: address drift in README badges, INSTALLATION, and STORAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Turing RK1 Kubernetes Cluster
 
-[![GitHub Release](https://img.shields.io/github/v/release/jfreed-dev/turing-rk1-cluster)](https://github.com/jfreed-dev/turing-rk1-cluster/releases)
-[![Lint](https://github.com/jfreed-dev/turing-rk1-cluster/actions/workflows/lint.yml/badge.svg)](https://github.com/jfreed-dev/turing-rk1-cluster/actions/workflows/lint.yml)
-[![CodeQL](https://github.com/jfreed-dev/turing-rk1-cluster/actions/workflows/codeql.yml/badge.svg)](https://github.com/jfreed-dev/turing-rk1-cluster/actions/workflows/codeql.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/freed-dev-llc/turing-rk1-cluster)](https://github.com/freed-dev-llc/turing-rk1-cluster/releases)
+[![Lint](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/lint.yml/badge.svg)](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/lint.yml)
+[![CodeQL](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/codeql.yml/badge.svg)](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Talos](https://img.shields.io/badge/Talos-v1.11.6-blue)](https://www.talos.dev/)
 [![K3s](https://img.shields.io/badge/K3s-v1.31-FFC61C)](https://k3s.io/)

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -97,7 +97,7 @@ Both distributions deploy the same Kubernetes workloads:
 
 | Component | Version | Purpose | Notes |
 |-----------|---------|---------|-------|
-| **MetalLB** | v0.14.9 | LoadBalancer | L2 mode, IP pool 10.10.88.80-99 |
+| **MetalLB** | v0.14.9 | LoadBalancer | L2 mode, IP pool 10.10.88.80-89 |
 | **NGINX Ingress** | Latest | Ingress Controller | External IP: 10.10.88.80 |
 | **Longhorn** | v1.7.2 | Distributed Storage | NVMe-backed on workers |
 | **Prometheus Stack** | Latest | Monitoring | Grafana + Alertmanager |

--- a/docs/INSTALLATION-K3S.md
+++ b/docs/INSTALLATION-K3S.md
@@ -181,7 +181,7 @@ wget -O armbian-turing-rk1.img.xz \
 |---------|----------|
 | BMC | 10.10.88.70 |
 | Cluster Nodes | 10.10.88.73-76 |
-| MetalLB Pool | 10.10.88.80-99 |
+| MetalLB Pool | 10.10.88.80-89 |
 | Kubernetes API | 10.10.88.73:6443 |
 
 ### Assigned LoadBalancer IPs

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -108,7 +108,7 @@ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 | Node | Role | Hostname | IP Address | Storage |
 |------|------|----------|------------|---------|
-| Node 1 | Control Plane | turing-cp1 | 10.10.88.73 | 31GB eMMC + 500GB NVMe |
+| Node 1 | Control Plane | turing-cp1 | 10.10.88.73 | 31GB eMMC (no NVMe by design) |
 | Node 2 | Worker | turing-w1 | 10.10.88.74 | 31GB eMMC + 500GB NVMe |
 | Node 3 | Worker | turing-w2 | 10.10.88.75 | 31GB eMMC + 500GB NVMe |
 | Node 4 | Worker | turing-w3 | 10.10.88.76 | 31GB eMMC + 500GB NVMe |
@@ -130,7 +130,7 @@ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 |---------|----------|
 | BMC | 10.10.88.70 |
 | Cluster Nodes | 10.10.88.73-76 |
-| MetalLB Pool | 10.10.88.80-99 |
+| MetalLB Pool | 10.10.88.80-89 |
 | Kubernetes API | 10.10.88.73:6443 |
 
 ### Assigned LoadBalancer IPs

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ See [COMPARISON.md](COMPARISON.md) for the complete feature matrix.
 
 Both installation methods deploy the same workloads:
 
-- **MetalLB** - Load balancer (IP pool: 10.10.88.80-99)
+- **MetalLB** - Load balancer (IP pool: 10.10.88.80-89)
 - **NGINX Ingress** - Ingress controller at 10.10.88.80
 - **Longhorn** - Distributed storage on NVMe drives
 - **Prometheus Stack** - Monitoring (Grafana, Prometheus, Alertmanager)
@@ -78,6 +78,8 @@ Helper scripts in `../scripts/`:
 |--------|---------|
 | `setup-k3s-node.sh` | Prepare Armbian node for K3s |
 | `deploy-k3s-cluster.sh` | Deploy K3s cluster from workstation |
+| `deploy-talos-cluster.sh` | Deploy Talos cluster from workstation |
+| `talos-cluster-status.sh` | Show Talos cluster + node status at a glance |
 | `wipe-cluster.sh` | Reset cluster for distribution switch |
 
 ### Switching Distributions

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -7,9 +7,9 @@ This document covers the storage setup for the Turing RK1 Kubernetes cluster usi
 | Node | eMMC (System) | NVMe (Data) | Total Longhorn |
 |------|---------------|-------------|----------------|
 | turing-cp1 | 31GB | - | ~24GB |
-| talos-0ow-v7t | 31GB | 500GB | ~481GB |
-| talos-6ed-cqn | 31GB | 500GB | ~481GB |
-| talos-700-itj | 31GB | 500GB | ~481GB |
+| turing-w1 | 31GB | 500GB | ~481GB |
+| turing-w2 | 31GB | 500GB | ~481GB |
+| turing-w3 | 31GB | 500GB | ~481GB |
 | **Total** | | | **~1.47TB** |
 
 ---
@@ -138,7 +138,7 @@ spec:
 Apply to worker nodes:
 
 ```bash
-for node in talos-0ow-v7t talos-6ed-cqn talos-700-itj; do
+for node in turing-w1 turing-w2 turing-w3; do
   kubectl patch nodes.longhorn.io/$node -n longhorn-system \
     --type=merge --patch-file=longhorn-node-patch.yaml
 done


### PR DESCRIPTION
## Summary

Findings from the 2026-05-19 multi-pass audit:

### README badges still on jfreed-dev
Three badge/link URLs (Release, Lint, CodeQL) pointed at the pre-transfer `jfreed-dev/turing-rk1-cluster`. Redirects work but canonical is `freed-dev-llc`. Updated all three.

### INSTALLATION.md cluster table — wrong CP storage
Node 1 (control plane) was listed as `31GB eMMC + 500GB NVMe`. Per README "Storage Limitation", CP has no NVMe by design (only the 3 workers do). Fixed to `31GB eMMC (no NVMe by design)`.

### MetalLB pool reconciliation
`cluster-config/metallb-config.yaml` (ground truth) uses `10.10.88.80-89`. Four docs claimed `80-99`; reconciled:
- `docs/README.md`, `docs/COMPARISON.md`, `docs/INSTALLATION.md`, `docs/INSTALLATION-K3S.md`

### STORAGE.md auto-generated Talos hostnames
Storage table and Longhorn `for node in …` loop used the auto-generated Talos node IDs (`talos-0ow-v7t` / `talos-6ed-cqn` / `talos-700-itj`) — those get replaced by `turing-w1/w2/w3` via the documented hostname patch. Copy-pasting the loop verbatim would fail. Renamed.

### docs/README.md scripts table — incomplete
Missing `deploy-talos-cluster.sh` and `talos-cluster-status.sh` (both exist in `scripts/`). Added.

## Test plan
- [ ] CI green (Lint, CodeQL — `actions` language only since CodeQL has no aarch64 build)