### PR TITLE
docs: tier-3 cleanup (~/Code paths, ingress-nginx beta, eMMC sizing)

### DIFF
--- a/CLUSTER_PLAN.md
+++ b/CLUSTER_PLAN.md
@@ -72,7 +72,7 @@ Power down all nodes first, then flash sequentially:
 
 ```bash
 # Set image path
-IMAGE_PATH="/home/jon/Code/turing-rk1-cluster/images/latest/metal-arm64.raw"
+IMAGE_PATH="$REPO_ROOT/images/latest/metal-arm64.raw"
 
 # Flash all 4 nodes (run from BMC or use tpi remotely)
 # Option A: Via BMC SSH
@@ -112,8 +112,8 @@ export WORKER_IPS=("10.10.88.74" "10.10.88.75" "10.10.88.76")
 export KUBERNETES_ENDPOINT="https://${CONTROL_PLANE_IP}:6443"
 
 # Working directory for configs
-mkdir -p ~/Code/turing-rk1-cluster/cluster-config
-cd ~/Code/turing-rk1-cluster/cluster-config
+mkdir -p $REPO_ROOT/cluster-config
+cd $REPO_ROOT/cluster-config
 ```
 
 ### Generate Cluster Secrets

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,19 +114,19 @@ flowchart TB
         LE["Longhorn Engine"]
 
         subgraph Node2Storage["Worker 1 Storage"]
-            eMMC2["eMMC<br/>31GB"]
+            eMMC2["eMMC<br/>~31GB usable"]
             NVMe2["NVMe<br/>500GB"]
             LR2["Longhorn<br/>Replica"]
         end
 
         subgraph Node3Storage["Worker 2 Storage"]
-            eMMC3["eMMC<br/>31GB"]
+            eMMC3["eMMC<br/>~31GB usable"]
             NVMe3["NVMe<br/>500GB"]
             LR3["Longhorn<br/>Replica"]
         end
 
         subgraph Node4Storage["Worker 3 Storage"]
-            eMMC4["eMMC<br/>31GB"]
+            eMMC4["eMMC<br/>~31GB usable"]
             NVMe4["NVMe<br/>500GB"]
             LR4["Longhorn<br/>Replica"]
         end

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -108,10 +108,10 @@ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 | Node | Role | Hostname | IP Address | Storage |
 |------|------|----------|------------|---------|
-| Node 1 | Control Plane | turing-cp1 | 10.10.88.73 | 31GB eMMC (no NVMe by design) |
-| Node 2 | Worker | turing-w1 | 10.10.88.74 | 31GB eMMC + 500GB NVMe |
-| Node 3 | Worker | turing-w2 | 10.10.88.75 | 31GB eMMC + 500GB NVMe |
-| Node 4 | Worker | turing-w3 | 10.10.88.76 | 31GB eMMC + 500GB NVMe |
+| Node 1 | Control Plane | turing-cp1 | 10.10.88.73 | ~31GB eMMC usable (no NVMe by design) |
+| Node 2 | Worker | turing-w1 | 10.10.88.74 | ~31GB eMMC + 500GB NVMe |
+| Node 3 | Worker | turing-w2 | 10.10.88.75 | ~31GB eMMC + 500GB NVMe |
+| Node 4 | Worker | turing-w3 | 10.10.88.76 | ~31GB eMMC + 500GB NVMe |
 
 **Hardware Specifications (per RK1 node):**
 - SoC: Rockchip RK3588 (8-core ARM64)
@@ -750,7 +750,7 @@ kubectl create namespace ingress-nginx
 kubectl label namespace ingress-nginx pod-security.kubernetes.io/enforce=privileged
 
 # Install NGINX Ingress Controller (cloud provider version for LoadBalancer support)
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.12.0-beta.0/deploy/static/provider/cloud/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.13.3/deploy/static/provider/cloud/deploy.yaml
 
 # Wait for controller to be ready
 kubectl wait --namespace ingress-nginx \

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -1,11 +1,15 @@
 # Quick Reference Card
 
+> `$REPO_ROOT` in the snippets below refers to your local checkout of this repo.
+> Either `export REPO_ROOT="$(pwd)"` from the repo root, or substitute the path
+> by hand.
+
 ## Cluster Access
 
 ```bash
 # Set environment
-export TALOSCONFIG=/home/jon/Code/turing-rk1-cluster/cluster-config/talosconfig
-export KUBECONFIG=/home/jon/Code/turing-rk1-cluster/cluster-config/kubeconfig
+export TALOSCONFIG=$REPO_ROOT/cluster-config/talosconfig
+export KUBECONFIG=$REPO_ROOT/cluster-config/kubeconfig
 
 # Or use explicit paths
 kubectl --kubeconfig=/path/to/kubeconfig get nodes


### PR DESCRIPTION
## Summary

Cosmetic follow-ups from the 2026-05-19 audit.

### Hardcoded `~/Code/turing-rk1-cluster` paths in tracked docs
Replaced with `$REPO_ROOT` so the snippets are portable:
- `CLUSTER_PLAN.md` (3x — IMAGE_PATH, mkdir, cd)
- `docs/QUICKREF.md` (2x — TALOSCONFIG, KUBECONFIG)
- Added a note at the top of `QUICKREF.md` explaining `$REPO_ROOT`.

### Stale beta-pinned ingress-nginx URL
`docs/INSTALLATION.md` had `controller-v1.12.0-beta.0` (pre-GA from late 2024). Bumped to `controller-v1.13.3` GA.

### eMMC 31GB vs 32GB clarity
Both numbers are correct (32GB nominal, ~31GB usable after format). Where the audit flagged inconsistency, tightened the wording:
- ARCHITECTURE Storage subgraph: `eMMC 31GB` → `eMMC ~31GB usable` (3 workers)
- INSTALLATION storage table: `31GB eMMC` → `~31GB eMMC`
- README hardware spec (32GB) left as-is — nominal capacity.

## Test plan
- [ ] CI green (Lint, CodeQL)