### PR TITLE
docs: fix License badge (MIT -> Apache 2.0) and bump Talos v1.11.6 -> v1.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![GitHub Release](https://img.shields.io/github/v/release/freed-dev-llc/turing-rk1-cluster)](https://github.com/freed-dev-llc/turing-rk1-cluster/releases)
 [![Lint](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/lint.yml/badge.svg)](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/lint.yml)
 [![CodeQL](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/codeql.yml/badge.svg)](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/codeql.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Talos](https://img.shields.io/badge/Talos-v1.11.6-blue)](https://www.talos.dev/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Talos](https://img.shields.io/badge/Talos-v1.13.2-blue)](https://www.talos.dev/)
 [![K3s](https://img.shields.io/badge/K3s-v1.31-FFC61C)](https://k3s.io/)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.34.1-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io/)
 
@@ -92,7 +92,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| Talos Linux | v1.11.6 | Immutable, API-driven Kubernetes OS |
+| Talos Linux | v1.13.2 | Immutable, API-driven Kubernetes OS |
 | Linux Kernel | 6.12.62 | Mainline kernel (ARM64) |
 
 ### Kubernetes Components
@@ -133,7 +133,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 | Component | Version | Purpose |
 |-----------|---------|---------|
 | Portainer Agent | v2.33.6 | Remote cluster management |
-| talosctl | v1.11.6 | Talos node management |
+| talosctl | v1.13.2 | Talos node management |
 | kubectl | v1.34.x | Kubernetes CLI |
 | Helm | v3.x | Package manager |
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -244,16 +244,16 @@ curl -s -X POST --data-binary @talos-schematic.yaml \
 
 ### Step 3: Image URLs
 
-**Current Image (Talos v1.11.6):**
+**Current Image (Talos v1.13.2):**
 ```
-https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.11.6/metal-arm64.raw.xz
+https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz
 ```
 
 To download locally:
 ```bash
 mkdir -p images/latest
 wget -O images/latest/metal-arm64.raw.xz \
-  "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.11.6/metal-arm64.raw.xz"
+  "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
 ```
 
 ---
@@ -268,16 +268,16 @@ Download the image locally first, then flash using `--image-path`:
 # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set
 
 # Download image locally
-wget -O /tmp/talos-rk1-v1.11.6.raw.xz \
-  "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.11.6/metal-arm64.raw.xz"
+wget -O /tmp/talos-rk1-v1.13.2.raw.xz \
+  "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
 
 # Flash control plane (node 1)
-tpi flash -n 1 --image-path /tmp/talos-rk1-v1.11.6.raw.xz
+tpi flash -n 1 --image-path /tmp/talos-rk1-v1.13.2.raw.xz
 
 # Flash worker nodes
 for node in 2 3 4; do
   echo "Flashing node $node..."
-  tpi flash -n $node --image-path /tmp/talos-rk1-v1.11.6.raw.xz
+  tpi flash -n $node --image-path /tmp/talos-rk1-v1.13.2.raw.xz
 done
 
 # Power on all nodes after flashing
@@ -293,7 +293,7 @@ If the node is running Ubuntu or another OS with SSH access:
 ssh ubuntu@<node-ip>
 
 # Download Talos image
-wget https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.11.6/metal-arm64.raw.xz
+wget https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz
 
 # Decompress
 xz -d metal-arm64.raw.xz
@@ -396,7 +396,7 @@ If a node boots from NVMe instead of eMMC, the NVMe likely has bootable content 
 8. **Flash Talos:**
    ```bash
    # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set \
-     tpi flash -n 1 --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.11.6/metal-arm64.raw.xz"
+     tpi flash -n 1 --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
    ```
 
 9. **Power on - node should now boot Talos from eMMC:**
@@ -657,7 +657,7 @@ If a worker was configured with a different cluster's secrets:
 ```bash
 # Reflash the node
 # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set \
-  tpi flash -n 2 --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.11.6/metal-arm64.raw.xz"
+  tpi flash -n 2 --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
 
 # Power on
 # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set tpi power on -n 2
@@ -945,7 +945,7 @@ nc -zv <node-ip> 50000
 ```bash
 # Must reflash the node
 # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set \
-  tpi flash -n <node> --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.11.6/metal-arm64.raw.xz"
+  tpi flash -n <node> --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
 ```
 
 ### Node Boots Wrong OS
@@ -992,7 +992,7 @@ talosctl -n <node-ip> mounts | grep nvme
 
 | Component | Version |
 |-----------|---------|
-| Talos | v1.11.6 |
+| Talos | v1.13.2 |
 | Kubernetes | v1.34.1 |
 | Longhorn | v1.7.2 |
 | MetalLB | v0.14.9 |


### PR DESCRIPTION
Two real drift items the first-pass audit agent missed:

### License badge MIT vs LICENSE file Apache 2.0
Same pattern as `turing-ansible-cluster` fix in #9 — repo's `LICENSE` is Apache 2.0 but the README badge advertised MIT. Updated badge text + URL.

### Talos v1.11.6 pinned in 18 places
Ground truth is the talos-image workflow's `images.json` output (https://armbian-builds.techki.to/turing-rk1/images.json), which reports `v1.13.2` (schematic unchanged). Bumped all references in README + `docs/INSTALLATION.md`.

K3s v1.31 badge and Kubernetes v1.34.1 badge left as-is — K3s matches inventory `v1.31.4+k3s1`; K8s is a separate question depending on what's actually running.

## Test plan
- [ ] CI green (Lint, CodeQL)