### PR TITLE
docs: pass-5 cleanup (misses from prior Talos + MetalLB + ingress bumps)

### DIFF
--- a/CLUSTER_PLAN.md
+++ b/CLUSTER_PLAN.md
@@ -13,7 +13,7 @@ Deploy a 4-node Kubernetes cluster on Turing RK1 boards (RK3588 SoC) with Talos 
 | Node 2 (Worker) | 10.10.88.74 |
 | Node 3 (Worker) | 10.10.88.75 |
 | Node 4 (Worker) | 10.10.88.76 |
-| OS | Talos Linux v1.11.6 |
+| OS | Talos Linux v1.13.2 |
 | Storage | NVMe (each node) + Longhorn distributed storage |
 | NPU | RK3588 NPU with RKNN Runtime |
 
@@ -22,7 +22,7 @@ Deploy a 4-node Kubernetes cluster on Turing RK1 boards (RK3588 SoC) with Talos 
 ## Phase 1: Talos Image Preparation
 
 ### Current Image Status
-- **Available**: `images/latest/metal-arm64.raw` (v1.11.6, 2.2GB decompressed)
+- **Available**: `images/latest/metal-arm64.raw` (v1.13.2, 2.2GB decompressed)
 - **Source**: https://factory.talos.dev
 
 ### Required System Extensions
@@ -43,12 +43,12 @@ Generate a new image with required extensions from [Talos Image Factory](https:/
 
 ```bash
 # 1. Go to https://factory.talos.dev
-# 2. Select: Single Board Computers → Talos v1.11.6 → Turing RK1
+# 2. Select: Single Board Computers → Talos v1.13.2 → Turing RK1
 # 3. Add extensions:
 #    - siderolabs/iscsi-tools
 #    - siderolabs/util-linux-tools
 # 4. Download and decompress:
-curl -LO https://factory.talos.dev/image/<schematic-id>/v1.11.6/metal-arm64.raw.xz
+curl -LO https://factory.talos.dev/image/<schematic-id>/v1.13.2/metal-arm64.raw.xz
 xz -d metal-arm64.raw.xz
 mv metal-arm64.raw images/latest/
 ```

--- a/README.md
+++ b/README.md
@@ -443,4 +443,4 @@ This is a personal homelab cluster. Configuration files and documentation are pr
 
 ## License
 
-Configuration files and documentation are provided under MIT license. Third-party components retain their original licenses.
+Configuration files and documentation are provided under the Apache 2.0 license (see [LICENSE](LICENSE)). Third-party components retain their original licenses.

--- a/docs/INSTALLATION-K3S.md
+++ b/docs/INSTALLATION-K3S.md
@@ -601,7 +601,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-  - 10.10.88.80-10.10.88.99
+  - 10.10.88.80-10.10.88.89
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement

--- a/docs/INSTALLATION-K3S.md
+++ b/docs/INSTALLATION-K3S.md
@@ -934,5 +934,5 @@ export TPI_HOSTNAME=10.10.88.70
 | K3s | v1.31.x |
 | Longhorn | v1.7.x |
 | MetalLB | v0.14.9 |
-| NGINX Ingress | v1.12.x |
+| NGINX Ingress | v1.13.x |
 | kube-prometheus-stack | latest |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -729,7 +729,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-    - 10.10.88.80-10.10.88.99
+    - 10.10.88.80-10.10.88.89
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -996,7 +996,7 @@ talosctl -n <node-ip> mounts | grep nvme
 | Kubernetes | v1.34.1 |
 | Longhorn | v1.7.2 |
 | MetalLB | v0.14.9 |
-| Ingress NGINX | v1.12.0-beta.0 |
+| Ingress NGINX | v1.13.3 |
 | kube-prometheus-stack | latest (Helm) |
 
 ---

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -66,7 +66,7 @@ talosctl -n 10.10.88.73 services
 talosctl -n 10.10.88.74 reboot
 
 # Upgrade Talos
-talosctl -n 10.10.88.74 upgrade --image ghcr.io/siderolabs/installer:v1.11.6
+talosctl -n 10.10.88.74 upgrade --image ghcr.io/siderolabs/installer:v1.13.2
 ```
 
 ### Storage


### PR DESCRIPTION
Pass-5 audit caught 8 real misses from earlier today's batch fixes whose sed patterns were too narrow.

- `README.md:446` License body text still said "MIT" — PR #25 only fixed the badge
- `CLUSTER_PLAN.md` (4 sites) — entirely skipped by Talos bump
- `docs/QUICKREF.md:69` talosctl upgrade installer:v1.11.6
- `docs/INSTALLATION.md:732` + `docs/INSTALLATION-K3S.md:604` MetalLB pool full-range form (PR #23 only matched short form)
- `docs/INSTALLATION.md:999` Version Reference table ingress beta
- `docs/INSTALLATION-K3S.md:937` K3s table NGINX Ingress v1.12.x → v1.13.x