### PR TITLE
chore: complete Talos v1.13.2 + K8s v1.35.0 bump across cluster-config + scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mermaid diagrams in `docs/` locked to `neutral` theme for cross-mode legibility (#21).
 - Dependabot config now ignores the `repo/u-boot-rockchip` submodule (updater crashes upstream) (#22).
 - README badges + INSTALLATION docs updated for the `jfreed-dev` → `freed-dev-llc` org migration (#23, #25).
-- INSTALLATION docs: Talos version bumped from v1.11.6 to v1.13.2 (#25).
+- INSTALLATION docs: Talos version bumped from v1.11.6 to v1.13.2 (#25, completed in #27 + this PR which caught references in CLUSTER_PLAN.md / QUICKREF.md / scripts/deploy-talos-cluster.sh / cluster-config/*.yaml that #25 missed).
+- **Cluster machineconfig** (`cluster-config/*.yaml`, 8 files): bumped `installer:v1.11.6` → `v1.13.2` and all Kubernetes component images (kubelet, kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler) from v1.34.1 → v1.35.0 to match the Kubernetes version Talos v1.13.2 actually ships. Applying these configs via `talosctl apply-config` will upgrade nodes to Talos v1.13.2 + K8s v1.35.0.
+- **Deploy script** (`scripts/deploy-talos-cluster.sh`): `TALOS_VERSION` default bumped from v1.11.6 to v1.13.2 so fresh deploys pull the matching image from the Factory.
+- README badges + INSTALLATION/COMPARISON Kubernetes version: v1.34.1 → v1.35.0 (matches what Talos v1.13.2 ships, per Talos Factory's `kubernetes_version` field in the manifest).
 - MetalLB pool range reconciled to ground-truth `10.10.88.80-89` across all docs (was inconsistent: `80-89` in 4 places, `80-99` in 4) (#23).
 - STORAGE.md hostnames switched from auto-generated `talos-0ow-v7t`-style IDs to `turing-w1/w2/w3` to match the documented hostname patch (#23).
 - INSTALLATION storage table corrected — Node 1 control plane has no NVMe by design (#23).
@@ -29,3 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - License badge: MIT → Apache 2.0 to match the actual `LICENSE` file (#25).
 - `docs/INSTALLATION.md` ingress-nginx URL was pinned to `v1.12.0-beta.0`; bumped to `v1.13.3` GA (#24).
 - `~/Code/turing-rk1-cluster` hardcoded paths in `CLUSTER_PLAN.md` and `docs/QUICKREF.md` generalized to `$REPO_ROOT` (#24).
+- `docs/INSTALLATION.md` Version Reference table cited ingress-nginx `v1.12.0-beta.0`; bumped to `v1.13.3` for parity with the install snippet at line 753 (#27).
+- `docs/INSTALLATION-K3S.md` K3s Ref table NGINX Ingress `v1.12.x` → `v1.13.x` (#27).
+- README License section body still said "MIT license" even after #25 fixed the badge; now says "Apache 2.0 license (see LICENSE)" (#27).
+- MetalLB pool YAML snippets at `docs/INSTALLATION.md:732` and `docs/INSTALLATION-K3S.md:604` still used `10.10.88.80-10.10.88.99` (full-range form); reconciled to `80-89` to match the table form and the ground-truth `cluster-config/metallb-config.yaml` (#27).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Talos](https://img.shields.io/badge/Talos-v1.13.2-blue)](https://www.talos.dev/)
 [![K3s](https://img.shields.io/badge/K3s-v1.31-FFC61C)](https://k3s.io/)
-[![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.34.1-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io/)
+[![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.35.0-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io/)
 
 A 4-node bare-metal Kubernetes cluster built on Turing RK1 compute modules, supporting both **Talos Linux** and **K3s on Armbian** distributions. Designed for edge computing, AI/ML workloads with NPU acceleration, and distributed storage.
 
@@ -99,7 +99,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 
 | Component | Version | Purpose |
 |-----------|---------|---------|
-| Kubernetes | v1.34.1 | Container orchestration |
+| Kubernetes | v1.35.0 | Container orchestration |
 | containerd | v2.1.5 | Container runtime |
 | etcd | Bundled | Distributed key-value store |
 
@@ -134,7 +134,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 |-----------|---------|---------|
 | Portainer Agent | v2.33.6 | Remote cluster management |
 | talosctl | v1.13.2 | Talos node management |
-| kubectl | v1.34.x | Kubernetes CLI |
+| kubectl | v1.35.x | Kubernetes CLI |
 | Helm | v3.x | Package manager |
 
 ---

--- a/cluster-config/controlplane-node1.yaml
+++ b/cluster-config/controlplane-node1.yaml
@@ -9,7 +9,7 @@ machine:
         key: <REDACTED>
     certSANs: []
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.34.1
+        image: ghcr.io/siderolabs/kubelet:v1.35.0
         extraMounts:
             - destination: /var/lib/longhorn
               type: bind
@@ -31,7 +31,7 @@ machine:
             - mountpoint: /var/lib/longhorn
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.11.6
+        image: ghcr.io/siderolabs/installer:v1.13.2
         wipe: false
     features:
         rbac: true
@@ -69,7 +69,7 @@ cluster:
     serviceAccount:
         key: <REDACTED>
     apiServer:
-        image: registry.k8s.io/kube-apiserver:v1.34.1
+        image: registry.k8s.io/kube-apiserver:v1.35.0
         certSANs:
             - 10.10.88.73
         disablePodSecurityPolicy: true
@@ -96,11 +96,11 @@ cluster:
             rules:
                 - level: Metadata
     controllerManager:
-        image: registry.k8s.io/kube-controller-manager:v1.34.1
+        image: registry.k8s.io/kube-controller-manager:v1.35.0
     proxy:
-        image: registry.k8s.io/kube-proxy:v1.34.1
+        image: registry.k8s.io/kube-proxy:v1.35.0
     scheduler:
-        image: registry.k8s.io/kube-scheduler:v1.34.1
+        image: registry.k8s.io/kube-scheduler:v1.35.0
     discovery:
         enabled: true
         registries:

--- a/cluster-config/controlplane-simple.yaml
+++ b/cluster-config/controlplane-simple.yaml
@@ -9,7 +9,7 @@ machine:
         key: <REDACTED>
     certSANs: []
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.34.1
+        image: ghcr.io/siderolabs/kubelet:v1.35.0
         extraMounts:
             - destination: /var/lib/longhorn
               type: bind
@@ -27,7 +27,7 @@ machine:
               dhcp: true
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.11.6
+        image: ghcr.io/siderolabs/installer:v1.13.2
         wipe: false
     features:
         rbac: true
@@ -65,7 +65,7 @@ cluster:
     serviceAccount:
         key: <REDACTED>
     apiServer:
-        image: registry.k8s.io/kube-apiserver:v1.34.1
+        image: registry.k8s.io/kube-apiserver:v1.35.0
         certSANs:
             - 10.10.88.73
         disablePodSecurityPolicy: true
@@ -92,11 +92,11 @@ cluster:
             rules:
                 - level: Metadata
     controllerManager:
-        image: registry.k8s.io/kube-controller-manager:v1.34.1
+        image: registry.k8s.io/kube-controller-manager:v1.35.0
     proxy:
-        image: registry.k8s.io/kube-proxy:v1.34.1
+        image: registry.k8s.io/kube-proxy:v1.35.0
     scheduler:
-        image: registry.k8s.io/kube-scheduler:v1.34.1
+        image: registry.k8s.io/kube-scheduler:v1.35.0
     discovery:
         enabled: true
         registries:

--- a/cluster-config/controlplane.yaml
+++ b/cluster-config/controlplane.yaml
@@ -18,7 +18,7 @@ machine:
 
     # Used to provide additional options to the kubelet.
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.34.1 # The `image` field is an optional reference to an alternative kubelet image.
+        image: ghcr.io/siderolabs/kubelet:v1.35.0 # The `image` field is an optional reference to an alternative kubelet image.
         defaultRuntimeSeccompProfileEnabled: true # Enable container runtime default Seccomp profile.
         disableManifestsDirectory: true # The `disableManifestsDirectory` field configures the kubelet to get static pod manifests from the /etc/kubernetes/manifests directory.
         
@@ -189,7 +189,7 @@ machine:
     # Used to provide instructions for installations.
     install:
         disk: /dev/mmcblk0 # The disk used for installations.
-        image: ghcr.io/siderolabs/installer:v1.11.6 # Allows for supplying the image used to perform the installation.
+        image: ghcr.io/siderolabs/installer:v1.13.2 # Allows for supplying the image used to perform the installation.
         wipe: false # Indicates if the installation disk should be wiped at installation time.
         
         # # Look up disk using disk attributes like model, size, serial and others.
@@ -413,7 +413,7 @@ cluster:
         key: <REDACTED>
     # API server specific configuration options.
     apiServer:
-        image: registry.k8s.io/kube-apiserver:v1.34.1 # The container image used in the API server manifest.
+        image: registry.k8s.io/kube-apiserver:v1.35.0 # The container image used in the API server manifest.
         # Extra certificate subject alternative names for the API server's certificate.
         certSANs:
             - 10.10.88.73
@@ -471,16 +471,16 @@ cluster:
         #         timeout: 3s
     # Controller manager server specific configuration options.
     controllerManager:
-        image: registry.k8s.io/kube-controller-manager:v1.34.1 # The container image used in the controller manager manifest.
+        image: registry.k8s.io/kube-controller-manager:v1.35.0 # The container image used in the controller manager manifest.
     # Kube-proxy server-specific configuration options
     proxy:
-        image: registry.k8s.io/kube-proxy:v1.34.1 # The container image used in the kube-proxy manifest.
+        image: registry.k8s.io/kube-proxy:v1.35.0 # The container image used in the kube-proxy manifest.
         
         # # Disable kube-proxy deployment on cluster bootstrap.
         # disabled: false
     # Scheduler server specific configuration options.
     scheduler:
-        image: registry.k8s.io/kube-scheduler:v1.34.1 # The container image used in the scheduler manifest.
+        image: registry.k8s.io/kube-scheduler:v1.35.0 # The container image used in the scheduler manifest.
     # Configures cluster member discovery.
     discovery:
         enabled: true # Enable the cluster membership discovery feature.

--- a/cluster-config/worker-node2.yaml
+++ b/cluster-config/worker-node2.yaml
@@ -9,7 +9,7 @@ machine:
         key: ""
     certSANs: []
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.34.1
+        image: ghcr.io/siderolabs/kubelet:v1.35.0
         extraMounts:
             - destination: /var/lib/longhorn
               type: bind
@@ -31,7 +31,7 @@ machine:
             - mountpoint: /var/lib/longhorn
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.11.6
+        image: ghcr.io/siderolabs/installer:v1.13.2
         wipe: false
     features:
         rbac: true

--- a/cluster-config/worker-node3.yaml
+++ b/cluster-config/worker-node3.yaml
@@ -9,7 +9,7 @@ machine:
         key: ""
     certSANs: []
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.34.1
+        image: ghcr.io/siderolabs/kubelet:v1.35.0
         extraMounts:
             - destination: /var/lib/longhorn
               type: bind
@@ -31,7 +31,7 @@ machine:
             - mountpoint: /var/lib/longhorn
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.11.6
+        image: ghcr.io/siderolabs/installer:v1.13.2
         wipe: false
     features:
         rbac: true

--- a/cluster-config/worker-node4.yaml
+++ b/cluster-config/worker-node4.yaml
@@ -9,7 +9,7 @@ machine:
         key: ""
     certSANs: []
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.34.1
+        image: ghcr.io/siderolabs/kubelet:v1.35.0
         extraMounts:
             - destination: /var/lib/longhorn
               type: bind
@@ -31,7 +31,7 @@ machine:
             - mountpoint: /var/lib/longhorn
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.11.6
+        image: ghcr.io/siderolabs/installer:v1.13.2
         wipe: false
     features:
         rbac: true

--- a/cluster-config/worker-simple.yaml
+++ b/cluster-config/worker-simple.yaml
@@ -9,7 +9,7 @@ machine:
         key: ""
     certSANs: []
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.34.1
+        image: ghcr.io/siderolabs/kubelet:v1.35.0
         extraMounts:
             - destination: /var/lib/longhorn
               type: bind
@@ -26,7 +26,7 @@ machine:
               dhcp: true
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.11.6
+        image: ghcr.io/siderolabs/installer:v1.13.2
         wipe: false
     features:
         rbac: true

--- a/cluster-config/worker.yaml
+++ b/cluster-config/worker.yaml
@@ -18,7 +18,7 @@ machine:
 
     # Used to provide additional options to the kubelet.
     kubelet:
-        image: ghcr.io/siderolabs/kubelet:v1.34.1 # The `image` field is an optional reference to an alternative kubelet image.
+        image: ghcr.io/siderolabs/kubelet:v1.35.0 # The `image` field is an optional reference to an alternative kubelet image.
         defaultRuntimeSeccompProfileEnabled: true # Enable container runtime default Seccomp profile.
         disableManifestsDirectory: true # The `disableManifestsDirectory` field configures the kubelet to get static pod manifests from the /etc/kubernetes/manifests directory.
         
@@ -189,7 +189,7 @@ machine:
     # Used to provide instructions for installations.
     install:
         disk: /dev/mmcblk0 # The disk used for installations.
-        image: ghcr.io/siderolabs/installer:v1.11.6 # Allows for supplying the image used to perform the installation.
+        image: ghcr.io/siderolabs/installer:v1.13.2 # Allows for supplying the image used to perform the installation.
         wipe: false # Indicates if the installation disk should be wiped at installation time.
         
         # # Look up disk using disk attributes like model, size, serial and others.
@@ -444,7 +444,7 @@ cluster:
 
     # # API server specific configuration options.
     # apiServer:
-    #     image: registry.k8s.io/kube-apiserver:v1.34.1 # The container image used in the API server manifest.
+    #     image: registry.k8s.io/kube-apiserver:v1.35.0 # The container image used in the API server manifest.
     #     # Extra arguments to supply to the API server.
     #     extraArgs:
     #         feature-gates: ServerSideApply=true
@@ -506,7 +506,7 @@ cluster:
 
     # # Controller manager server specific configuration options.
     # controllerManager:
-    #     image: registry.k8s.io/kube-controller-manager:v1.34.1 # The container image used in the controller manager manifest.
+    #     image: registry.k8s.io/kube-controller-manager:v1.35.0 # The container image used in the controller manager manifest.
     #     # Extra arguments to supply to the controller manager.
     #     extraArgs:
     #         feature-gates: ServerSideApply=true
@@ -514,7 +514,7 @@ cluster:
     # # Kube-proxy server-specific configuration options
     # proxy:
     #     disabled: false # Disable kube-proxy deployment on cluster bootstrap.
-    #     image: registry.k8s.io/kube-proxy:v1.34.1 # The container image used in the kube-proxy manifest.
+    #     image: registry.k8s.io/kube-proxy:v1.35.0 # The container image used in the kube-proxy manifest.
     #     mode: ipvs # proxy mode of kube-proxy.
     #     # Extra arguments to supply to kube-proxy.
     #     extraArgs:
@@ -522,7 +522,7 @@ cluster:
 
     # # Scheduler server specific configuration options.
     # scheduler:
-    #     image: registry.k8s.io/kube-scheduler:v1.34.1 # The container image used in the scheduler manifest.
+    #     image: registry.k8s.io/kube-scheduler:v1.35.0 # The container image used in the scheduler manifest.
     #     # Extra arguments to supply to the scheduler.
     #     extraArgs:
     #         feature-gates: AllBeta=true

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -22,7 +22,7 @@ This document provides a comprehensive comparison between the two Kubernetes dis
 
 | Feature | Talos Linux | K3s on Armbian |
 |---------|-------------|----------------|
-| **Kubernetes Version** | v1.34.1 | v1.31.x (latest) |
+| **Kubernetes Version** | v1.35.0 | v1.31.x (latest) |
 | **Container Runtime** | containerd v2.1.5 | containerd |
 | **etcd** | Bundled (Talos managed) | Bundled (SQLite or etcd) |
 | **CNI** | Flannel (bundled) | Flannel (default) |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -644,10 +644,10 @@ kubectl get nodes -w
 
 # Expected output:
 # NAME         STATUS   ROLES           AGE   VERSION
-# turing-cp1   Ready    control-plane   10m   v1.34.1
-# turing-w1    Ready    <none>          2m    v1.34.1
-# turing-w2    Ready    <none>          2m    v1.34.1
-# turing-w3    Ready    <none>          2m    v1.34.1
+# turing-cp1   Ready    control-plane   10m   v1.35.0
+# turing-w1    Ready    <none>          2m    v1.35.0
+# turing-w2    Ready    <none>          2m    v1.35.0
+# turing-w3    Ready    <none>          2m    v1.35.0
 ```
 
 ### If Worker Has Wrong Certificates
@@ -911,10 +911,10 @@ kubectl get ingress -A
 
 ```
 NAME         STATUS   ROLES           AGE   VERSION
-turing-cp1   Ready    control-plane   1h    v1.34.1
-turing-w1    Ready    <none>          1h    v1.34.1
-turing-w2    Ready    <none>          1h    v1.34.1
-turing-w3    Ready    <none>          1h    v1.34.1
+turing-cp1   Ready    control-plane   1h    v1.35.0
+turing-w1    Ready    <none>          1h    v1.35.0
+turing-w2    Ready    <none>          1h    v1.35.0
+turing-w3    Ready    <none>          1h    v1.35.0
 ```
 
 ---
@@ -993,7 +993,7 @@ talosctl -n <node-ip> mounts | grep nvme
 | Component | Version |
 |-----------|---------|
 | Talos | v1.13.2 |
-| Kubernetes | v1.34.1 |
+| Kubernetes | v1.35.0 |
 | Longhorn | v1.7.2 |
 | MetalLB | v0.14.9 |
 | Ingress NGINX | v1.13.3 |

--- a/scripts/deploy-talos-cluster.sh
+++ b/scripts/deploy-talos-cluster.sh
@@ -22,7 +22,7 @@ if [[ -f "${PROJECT_DIR}/.env" ]]; then
 fi
 IMAGE_DIR="${PROJECT_DIR}/images/latest"
 TALOS_IMAGE="${IMAGE_DIR}/metal-arm64.raw"
-TALOS_VERSION="v1.11.6"
+TALOS_VERSION="v1.13.2"
 
 # Network configuration
 BMC_HOST="${BMC_HOST:-10.10.88.70}"


### PR DESCRIPTION
Pass-6 audit caught that prior Talos v1.11.6 → v1.13.2 doc bumps left the actual deploy artifacts behind. This PR completes the upgrade end-to-end.

### 🔴 Operational changes
- `scripts/deploy-talos-cluster.sh:25`: `TALOS_VERSION="v1.11.6"` → `"v1.13.2"`
- `cluster-config/*.yaml` (8 files): `installer:v1.11.6` → `installer:v1.13.2`
- `cluster-config/*.yaml` Kubernetes component images (kubelet, kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler): v1.34.1 → v1.35.0 (matches what Talos v1.13.2 ships per Factory `kubernetes_version` field)

### Doc updates following from the operational changes
- README badges + tables: Kubernetes v1.34.1 → v1.35.0 (3 places)
- COMPARISON.md Kubernetes Version cell same

### CHANGELOG
- Added entries for #27 follow-ups (License body, MetalLB YAML full-range form, ingress versions) and this PR.

**Apply impact**: `talosctl apply-config cluster-config/...` will upgrade nodes to Talos v1.13.2 + K8s v1.35.0 on next pass.