### PR TITLE
ci(dependabot): PAT-based approve/merge + semver-major guard

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,6 @@
 name: Dependabot Auto-Merge
 
-on:
-  pull_request:
+on: pull_request
 
 permissions:
   contents: write
@@ -9,17 +8,22 @@ permissions:
 
 jobs:
   auto-merge:
-    name: Auto-Merge
     runs-on: [self-hosted, linux]
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Approve PR
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Auto-approve patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
-
-      - name: Enable auto-merge
+      - name: Auto-merge patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,10 +17,10 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
 
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## Why
Two issues in this repo's Dependabot auto-merge:
1. The self-approve step used the Actions token, which GitHub blocks from approving PRs (`addPullRequestReview`) — so auto-merge could never fire.
2. Unlike the other 3 repos, this workflow had **no version-type guard**, so it would auto-approve **major** bumps too, and lacked the `fetch-metadata` step.

## Change
Replace with the canonical workflow shared by the other repos (now byte-identical):
- approve + merge run through `secrets.DEPENDABOT_AUTOMERGE_TOKEN` (fine-grained PAT owned by `jfreed-dev`, the CODEOWNER)
- adds `if: update-type != version-update:semver-major` so **major bumps are left for manual review**

Requires org secret `DEPENDABOT_AUTOMERGE_TOKEN` (Pull requests: RW, Contents: RW). Part of the org-wide fix (modules #61, provider #93, ansible #14).
