### PR TITLE
fix(talos): bump v1.13.2 → v1.13.5 to avoid kube-scheduler crash on K8s v1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot config now ignores the `repo/u-boot-rockchip` submodule (updater crashes upstream) (#22).
 - README badges + INSTALLATION docs updated for the `jfreed-dev` → `freed-dev-llc` org migration (#23, #25).
 - INSTALLATION docs: Talos version bumped from v1.11.6 to v1.13.2 (#25, completed in #27 + this PR which caught references in CLUSTER_PLAN.md / QUICKREF.md / scripts/deploy-talos-cluster.sh / cluster-config/*.yaml that #25 missed).
-- **Cluster machineconfig** (`cluster-config/*.yaml`, 8 files): bumped `installer:v1.11.6` → `v1.13.2` and all Kubernetes component images (kubelet, kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler) from v1.34.1 → v1.35.0 to match the Kubernetes version Talos v1.13.2 actually ships. Applying these configs via `talosctl apply-config` will upgrade nodes to Talos v1.13.2 + K8s v1.35.0.
+- **Cluster machineconfig** (`cluster-config/*.yaml`, 8 files): bumped `installer:v1.11.6` → `v1.13.2` and all Kubernetes component images (kubelet, kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler) from v1.34.1 → v1.35.0 to match the Kubernetes version Talos v1.13.2 actually ships. These configs are applied via `talosctl apply-config` on fresh deploys; upgrading an existing cluster instead requires `talosctl upgrade` (OS) + `talosctl upgrade-k8s` (Kubernetes), since `apply-config` alone does not reinstall the OS.
 - **Deploy script** (`scripts/deploy-talos-cluster.sh`): `TALOS_VERSION` default bumped from v1.11.6 to v1.13.2 so fresh deploys pull the matching image from the Factory.
 - README badges + INSTALLATION/COMPARISON Kubernetes version: v1.34.1 → v1.35.0 (matches what Talos v1.13.2 ships, per Talos Factory's `kubernetes_version` field in the manifest).
 - MetalLB pool range reconciled to ground-truth `10.10.88.80-89` across all docs (was inconsistent: `80-89` in 4 places, `80-99` in 4) (#23).
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Talos `v1.13.2` → `v1.13.5`** (`cluster-config/*.yaml` 8 installer images, `scripts/deploy-talos-cluster.sh`, plus README / INSTALLATION / QUICKREF / CLUSTER_PLAN references): Talos v1.13.2 crash-loops `kube-scheduler` when running Kubernetes v1.35 — it renders the Kubernetes 1.36-only scheduler plugin extension points (`placementGenerate` / `placementScore`) into the generated scheduler config, which the v1.35 scheduler rejects with a strict-decoding error ([siderolabs/talos#13350](https://github.com/siderolabs/talos/issues/13350)). Fixed upstream in v1.13.3; pinned to the latest v1.13 patch, `v1.13.5`. Kubernetes stays at `v1.35.0` (within Talos v1.13's supported 1.31–1.36 range).
+- `CLUSTER_PLAN.md` `kubectl get nodes` example output still showed Kubernetes `v1.34.x`; bumped to `v1.35.x` to match the `v1.35.0` bump applied across the other docs.
 - License badge: MIT → Apache 2.0 to match the actual `LICENSE` file (#25).
 - `docs/INSTALLATION.md` ingress-nginx URL was pinned to `v1.12.0-beta.0`; bumped to `v1.13.3` GA (#24).
 - `~/Code/turing-rk1-cluster` hardcoded paths in `CLUSTER_PLAN.md` and `docs/QUICKREF.md` generalized to `$REPO_ROOT` (#24).

--- a/CLUSTER_PLAN.md
+++ b/CLUSTER_PLAN.md
@@ -13,7 +13,7 @@ Deploy a 4-node Kubernetes cluster on Turing RK1 boards (RK3588 SoC) with Talos 
 | Node 2 (Worker) | 10.10.88.74 |
 | Node 3 (Worker) | 10.10.88.75 |
 | Node 4 (Worker) | 10.10.88.76 |
-| OS | Talos Linux v1.13.2 |
+| OS | Talos Linux v1.13.5 |
 | Storage | NVMe (each node) + Longhorn distributed storage |
 | NPU | RK3588 NPU with RKNN Runtime |
 
@@ -22,7 +22,7 @@ Deploy a 4-node Kubernetes cluster on Turing RK1 boards (RK3588 SoC) with Talos 
 ## Phase 1: Talos Image Preparation
 
 ### Current Image Status
-- **Available**: `images/latest/metal-arm64.raw` (v1.13.2, 2.2GB decompressed)
+- **Available**: `images/latest/metal-arm64.raw` (v1.13.5, 2.2GB decompressed)
 - **Source**: https://factory.talos.dev
 
 ### Required System Extensions
@@ -43,12 +43,12 @@ Generate a new image with required extensions from [Talos Image Factory](https:/
 
 ```bash
 # 1. Go to https://factory.talos.dev
-# 2. Select: Single Board Computers → Talos v1.13.2 → Turing RK1
+# 2. Select: Single Board Computers → Talos v1.13.5 → Turing RK1
 # 3. Add extensions:
 #    - siderolabs/iscsi-tools
 #    - siderolabs/util-linux-tools
 # 4. Download and decompress:
-curl -LO https://factory.talos.dev/image/<schematic-id>/v1.13.2/metal-arm64.raw.xz
+curl -LO https://factory.talos.dev/image/<schematic-id>/v1.13.5/metal-arm64.raw.xz
 xz -d metal-arm64.raw.xz
 mv metal-arm64.raw images/latest/
 ```
@@ -276,10 +276,10 @@ kubectl get nodes
 Expected output:
 ```
 NAME         STATUS   ROLES           AGE   VERSION
-turing-cp1   Ready    control-plane   Xm    v1.34.x
-turing-w1    Ready    <none>          Xm    v1.34.x
-turing-w2    Ready    <none>          Xm    v1.34.x
-turing-w3    Ready    <none>          Xm    v1.34.x
+turing-cp1   Ready    control-plane   Xm    v1.35.x
+turing-w1    Ready    <none>          Xm    v1.35.x
+turing-w2    Ready    <none>          Xm    v1.35.x
+turing-w3    Ready    <none>          Xm    v1.35.x
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Lint](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/lint.yml/badge.svg)](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/lint.yml)
 [![CodeQL](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/codeql.yml/badge.svg)](https://github.com/freed-dev-llc/turing-rk1-cluster/actions/workflows/codeql.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Talos](https://img.shields.io/badge/Talos-v1.13.2-blue)](https://www.talos.dev/)
+[![Talos](https://img.shields.io/badge/Talos-v1.13.5-blue)](https://www.talos.dev/)
 [![K3s](https://img.shields.io/badge/K3s-v1.31-FFC61C)](https://k3s.io/)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.35.0-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io/)
 
@@ -100,7 +100,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 
 | Component | Version | Notes |
 |-----------|---------|-------|
-| Talos Linux | v1.13.2 | Immutable, API-driven Kubernetes OS |
+| Talos Linux | v1.13.5 | Immutable, API-driven Kubernetes OS |
 | Linux Kernel | 6.12.62 | Mainline kernel (ARM64) |
 
 ### Kubernetes Components
@@ -141,7 +141,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 | Component | Version | Purpose |
 |-----------|---------|---------|
 | Portainer Agent | v2.33.6 | Remote cluster management |
-| talosctl | v1.13.2 | Talos node management |
+| talosctl | v1.13.5 | Talos node management |
 | kubectl | v1.35.x | Kubernetes CLI |
 | Helm | v3.x | Package manager |
 

--- a/cluster-config/controlplane-node1.yaml
+++ b/cluster-config/controlplane-node1.yaml
@@ -31,7 +31,7 @@ machine:
             - mountpoint: /var/lib/longhorn
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.13.2
+        image: ghcr.io/siderolabs/installer:v1.13.5
         wipe: false
     features:
         rbac: true

--- a/cluster-config/controlplane-simple.yaml
+++ b/cluster-config/controlplane-simple.yaml
@@ -27,7 +27,7 @@ machine:
               dhcp: true
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.13.2
+        image: ghcr.io/siderolabs/installer:v1.13.5
         wipe: false
     features:
         rbac: true

--- a/cluster-config/controlplane.yaml
+++ b/cluster-config/controlplane.yaml
@@ -189,7 +189,7 @@ machine:
     # Used to provide instructions for installations.
     install:
         disk: /dev/mmcblk0 # The disk used for installations.
-        image: ghcr.io/siderolabs/installer:v1.13.2 # Allows for supplying the image used to perform the installation.
+        image: ghcr.io/siderolabs/installer:v1.13.5 # Allows for supplying the image used to perform the installation.
         wipe: false # Indicates if the installation disk should be wiped at installation time.
         
         # # Look up disk using disk attributes like model, size, serial and others.

--- a/cluster-config/worker-node2.yaml
+++ b/cluster-config/worker-node2.yaml
@@ -31,7 +31,7 @@ machine:
             - mountpoint: /var/lib/longhorn
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.13.2
+        image: ghcr.io/siderolabs/installer:v1.13.5
         wipe: false
     features:
         rbac: true

--- a/cluster-config/worker-node3.yaml
+++ b/cluster-config/worker-node3.yaml
@@ -31,7 +31,7 @@ machine:
             - mountpoint: /var/lib/longhorn
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.13.2
+        image: ghcr.io/siderolabs/installer:v1.13.5
         wipe: false
     features:
         rbac: true

--- a/cluster-config/worker-node4.yaml
+++ b/cluster-config/worker-node4.yaml
@@ -31,7 +31,7 @@ machine:
             - mountpoint: /var/lib/longhorn
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.13.2
+        image: ghcr.io/siderolabs/installer:v1.13.5
         wipe: false
     features:
         rbac: true

--- a/cluster-config/worker-simple.yaml
+++ b/cluster-config/worker-simple.yaml
@@ -26,7 +26,7 @@ machine:
               dhcp: true
     install:
         disk: /dev/mmcblk0
-        image: ghcr.io/siderolabs/installer:v1.13.2
+        image: ghcr.io/siderolabs/installer:v1.13.5
         wipe: false
     features:
         rbac: true

--- a/cluster-config/worker.yaml
+++ b/cluster-config/worker.yaml
@@ -189,7 +189,7 @@ machine:
     # Used to provide instructions for installations.
     install:
         disk: /dev/mmcblk0 # The disk used for installations.
-        image: ghcr.io/siderolabs/installer:v1.13.2 # Allows for supplying the image used to perform the installation.
+        image: ghcr.io/siderolabs/installer:v1.13.5 # Allows for supplying the image used to perform the installation.
         wipe: false # Indicates if the installation disk should be wiped at installation time.
         
         # # Look up disk using disk attributes like model, size, serial and others.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -244,16 +244,16 @@ curl -s -X POST --data-binary @talos-schematic.yaml \
 
 ### Step 3: Image URLs
 
-**Current Image (Talos v1.13.2):**
+**Current Image (Talos v1.13.5):**
 ```
-https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz
+https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.5/metal-arm64.raw.xz
 ```
 
 To download locally:
 ```bash
 mkdir -p images/latest
 wget -O images/latest/metal-arm64.raw.xz \
-  "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
+  "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.5/metal-arm64.raw.xz"
 ```
 
 ---
@@ -268,16 +268,16 @@ Download the image locally first, then flash using `--image-path`:
 # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set
 
 # Download image locally
-wget -O /tmp/talos-rk1-v1.13.2.raw.xz \
-  "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
+wget -O /tmp/talos-rk1-v1.13.5.raw.xz \
+  "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.5/metal-arm64.raw.xz"
 
 # Flash control plane (node 1)
-tpi flash -n 1 --image-path /tmp/talos-rk1-v1.13.2.raw.xz
+tpi flash -n 1 --image-path /tmp/talos-rk1-v1.13.5.raw.xz
 
 # Flash worker nodes
 for node in 2 3 4; do
   echo "Flashing node $node..."
-  tpi flash -n $node --image-path /tmp/talos-rk1-v1.13.2.raw.xz
+  tpi flash -n $node --image-path /tmp/talos-rk1-v1.13.5.raw.xz
 done
 
 # Power on all nodes after flashing
@@ -293,7 +293,7 @@ If the node is running Ubuntu or another OS with SSH access:
 ssh ubuntu@<node-ip>
 
 # Download Talos image
-wget https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz
+wget https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.5/metal-arm64.raw.xz
 
 # Decompress
 xz -d metal-arm64.raw.xz
@@ -396,7 +396,7 @@ If a node boots from NVMe instead of eMMC, the NVMe likely has bootable content 
 8. **Flash Talos:**
    ```bash
    # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set \
-     tpi flash -n 1 --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
+     tpi flash -n 1 --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.5/metal-arm64.raw.xz"
    ```
 
 9. **Power on - node should now boot Talos from eMMC:**
@@ -657,7 +657,7 @@ If a worker was configured with a different cluster's secrets:
 ```bash
 # Reflash the node
 # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set \
-  tpi flash -n 2 --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
+  tpi flash -n 2 --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.5/metal-arm64.raw.xz"
 
 # Power on
 # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set tpi power on -n 2
@@ -945,7 +945,7 @@ nc -zv <node-ip> 50000
 ```bash
 # Must reflash the node
 # Ensure TPI_USERNAME, TPI_PASSWORD, TPI_HOSTNAME env vars are set \
-  tpi flash -n <node> --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.2/metal-arm64.raw.xz"
+  tpi flash -n <node> --image-url "https://factory.talos.dev/image/85f683902139269fbc5a7f64ea94a694d31e0b3d94347a225223fcbd042083ae/v1.13.5/metal-arm64.raw.xz"
 ```
 
 ### Node Boots Wrong OS
@@ -992,7 +992,7 @@ talosctl -n <node-ip> mounts | grep nvme
 
 | Component | Version |
 |-----------|---------|
-| Talos | v1.13.2 |
+| Talos | v1.13.5 |
 | Kubernetes | v1.35.0 |
 | Longhorn | v1.7.2 |
 | MetalLB | v0.14.9 |

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -66,7 +66,7 @@ talosctl -n 10.10.88.73 services
 talosctl -n 10.10.88.74 reboot
 
 # Upgrade Talos
-talosctl -n 10.10.88.74 upgrade --image ghcr.io/siderolabs/installer:v1.13.2
+talosctl -n 10.10.88.74 upgrade --image ghcr.io/siderolabs/installer:v1.13.5
 ```
 
 ### Storage

--- a/scripts/deploy-talos-cluster.sh
+++ b/scripts/deploy-talos-cluster.sh
@@ -22,7 +22,7 @@ if [[ -f "${PROJECT_DIR}/.env" ]]; then
 fi
 IMAGE_DIR="${PROJECT_DIR}/images/latest"
 TALOS_IMAGE="${IMAGE_DIR}/metal-arm64.raw"
-TALOS_VERSION="v1.13.2"
+TALOS_VERSION="v1.13.5"
 
 # Network configuration
 BMC_HOST="${BMC_HOST:-10.10.88.70}"


### PR DESCRIPTION
## Why

PR #28 paired **Talos v1.13.2** with **Kubernetes v1.35.0** in the cluster machine configs. That specific pairing is broken: Talos v1.13.2 has a regression ([siderolabs/talos#13350](https://github.com/siderolabs/talos/issues/13350)) where it renders the Kubernetes **1.36-only** scheduler plugin extension points (`placementGenerate` / `placementScore`) into the generated `kube-scheduler` config. The v1.35 scheduler rejects those unknown fields with a strict-decoding error and exits immediately, so **all `kube-scheduler` static pods crash-loop** → no pod scheduling on the control plane.

- Fixed upstream by [siderolabs/talos#13357](https://github.com/siderolabs/talos/pull/13357) (merged 2026-05-14), first released in **Talos v1.13.3**.
- v1.13.2 was published 2026-05-12, before that fix — #28 merged 2026-05-19, so v1.13.2 was simply the newest patch at the time.

## What

Pin the **latest v1.13 patch, `v1.13.5`** (released 2026-06-22), which carries the scheduler fix forward. **Kubernetes stays at v1.35.0** — it is well within Talos v1.13's supported range (1.31–1.36), and all six component image tags already exist and are unchanged.

- `cluster-config/*.yaml` — 8 `installer` images `v1.13.2` → `v1.13.5`
- `scripts/deploy-talos-cluster.sh` — `TALOS_VERSION` → `v1.13.5`
- `README.md`, `docs/INSTALLATION.md`, `docs/QUICKREF.md`, `CLUSTER_PLAN.md` — Talos version references → `v1.13.5`
- `CLUSTER_PLAN.md` — `kubectl get nodes` example output `v1.34.x` → `v1.35.x` (a straggler missed by #28's K8s `v1.34.1` → `v1.35.0` bump)
- `CHANGELOG.md` — corrected the #28 note that claimed `talosctl apply-config` upgrades running nodes (OS upgrades require `talosctl upgrade`; Kubernetes requires `talosctl upgrade-k8s`)

## Verification

- All 6 image tags exist (anonymous registry queries): `ghcr.io/siderolabs/installer:v1.13.5`, `ghcr.io/siderolabs/kubelet:v1.35.0`, and the four `registry.k8s.io/kube-*:v1.35.0`.
- `yamllint -c .yamllint.yml .` — pass.
- `markdownlint-cli2` with `.markdownlint.json` — 0 errors.
- No `v1.13.2` references remain outside the historical CHANGELOG entry; all 8 configs confirmed at `installer:v1.13.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
