### PR TITLE
fix(scripts): harden cluster scripts (data-loss guards, reliability, secret hygiene)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cluster-config/talosconfig
 cluster-config/secrets.yaml
 cluster-config/*-final.yaml
 cluster-config/*-generated.yaml
+cluster-config/*-patched.yaml
 cluster-config/controlplane-node[0-9].yaml
 *.key
 *.pem

--- a/scripts/deploy-k3s-cluster.sh
+++ b/scripts/deploy-k3s-cluster.sh
@@ -2,7 +2,7 @@
 # Deploy K3s Cluster to Turing RK1 nodes
 # Run from workstation with SSH access to all nodes
 
-set -e
+set -euo pipefail
 
 # Node configuration
 SERVER_IP="10.10.88.73"
@@ -16,19 +16,31 @@ echo ""
 
 # Install K3s Server
 echo "[1/4] Installing K3s Server on $SERVER_IP..."
-ssh "$SSH_USER@$SERVER_IP" << 'REMOTE_SCRIPT'
+# shellcheck disable=SC2087 # $SERVER_IP intentionally expanded client-side for --tls-san
+ssh "$SSH_USER@$SERVER_IP" << REMOTE_SCRIPT
+set -eo pipefail
 curl -sfL https://get.k3s.io | sh -s - server \
   --cluster-init \
   --disable=traefik \
   --disable=servicelb \
   --write-kubeconfig-mode=644 \
-  --tls-san=10.10.88.73 \
+  --tls-san=$SERVER_IP \
   --node-name=k3s-server \
   --flannel-backend=vxlan
 REMOTE_SCRIPT
 
-echo "Waiting for server to be ready..."
-sleep 30
+echo "Waiting for K3s server to be ready (node-token + API)..."
+for attempt in $(seq 1 60); do
+  if ssh "$SSH_USER@$SERVER_IP" "test -s /var/lib/rancher/k3s/server/node-token && k3s kubectl get --raw='/readyz'" >/dev/null 2>&1; then
+    echo "Server ready (after $attempt checks)"
+    break
+  fi
+  if [[ "$attempt" -eq 60 ]]; then
+    echo "ERROR: K3s server not ready after ~5 minutes" >&2
+    exit 1
+  fi
+  sleep 5
+done
 
 # Get token
 echo "[2/4] Getting node token..."
@@ -43,6 +55,7 @@ for i in "${!AGENT_IPS[@]}"; do
   echo "  Installing on $AGENT_IP ($AGENT_NAME)..."
   # shellcheck disable=SC2087 # Variables intentionally expanded client-side
   ssh "$SSH_USER@$AGENT_IP" << REMOTE_SCRIPT
+set -eo pipefail
 curl -sfL https://get.k3s.io | K3S_URL=https://$SERVER_IP:6443 K3S_TOKEN=$K3S_TOKEN sh -s - agent \
   --node-name=$AGENT_NAME
 REMOTE_SCRIPT

--- a/scripts/deploy-talos-cluster.sh
+++ b/scripts/deploy-talos-cluster.sh
@@ -751,7 +751,8 @@ reset_cluster() {
 
     # Clean up local configs
     log_info "Cleaning up local configuration..."
-    rm -f "$CONFIG_DIR"/{controlplane,worker}*.yaml
+    # Only remove generated artifacts — NOT hand-authored *-patch.yaml / *-simple.yaml / *.example.yaml
+    rm -f "$CONFIG_DIR"/controlplane.yaml "$CONFIG_DIR"/worker.yaml "$CONFIG_DIR"/*-patched.yaml
     rm -f "$CONFIG_DIR"/talosconfig
     rm -f "$CONFIG_DIR"/kubeconfig
     # Keep secrets.yaml for redeployment

--- a/scripts/setup-k3s-node.sh
+++ b/scripts/setup-k3s-node.sh
@@ -3,9 +3,9 @@
 # Usage: ./setup-k3s-node.sh <hostname>
 # Example: ./setup-k3s-node.sh k3s-server
 
-set -e
+set -euo pipefail
 
-HOSTNAME=${1:-$(hostname)}
+HOSTNAME="${1:-$(hostname)}"
 
 echo "=== Turing RK1 K3s Node Setup ==="
 echo "Hostname: $HOSTNAME"
@@ -64,19 +64,27 @@ sed -i '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
 # Setup NVMe if present
 echo "[8/8] Setting up NVMe storage..."
 if [ -b /dev/nvme0n1 ]; then
-  if ! mount | grep -q "/var/lib/longhorn"; then
+  if findmnt /var/lib/longhorn >/dev/null 2>&1; then
+    echo "  NVMe already mounted at /var/lib/longhorn"
+  elif { blkid /dev/nvme0n1p1 >/dev/null 2>&1 || lsblk -nro FSTYPE /dev/nvme0n1 | grep -q .; } && [ "${FORCE_WIPE:-0}" != "1" ]; then
+    echo "  ERROR: /dev/nvme0n1 already contains a filesystem but is not mounted at /var/lib/longhorn." >&2
+    echo "  Refusing to format (would destroy existing data). Set FORCE_WIPE=1 to override." >&2
+    exit 1
+  else
     wipefs -a /dev/nvme0n1 2>/dev/null || true
     parted /dev/nvme0n1 --script mklabel gpt
     parted /dev/nvme0n1 --script mkpart primary xfs 0% 100%
-    sleep 2
+    partprobe /dev/nvme0n1
+    udevadm settle
     mkfs.xfs -f /dev/nvme0n1p1
     mkdir -p /var/lib/longhorn
     UUID=$(blkid -s UUID -o value /dev/nvme0n1p1)
-    echo "UUID=$UUID /var/lib/longhorn xfs defaults,noatime 0 2" >> /etc/fstab
+    [ -n "$UUID" ] || { echo "  ERROR: could not read UUID of /dev/nvme0n1p1" >&2; exit 1; }
+    if ! grep -q " /var/lib/longhorn " /etc/fstab; then
+      echo "UUID=$UUID /var/lib/longhorn xfs defaults,noatime,nofail,x-systemd.device-timeout=10 0 0" >> /etc/fstab
+    fi
     mount -a
     echo "  NVMe mounted at /var/lib/longhorn"
-  else
-    echo "  NVMe already mounted"
   fi
 else
   echo "  No NVMe detected"

--- a/scripts/talos-cluster-status.sh
+++ b/scripts/talos-cluster-status.sh
@@ -3,7 +3,9 @@
 # Turing RK1 Cluster Status Script
 # Detects cluster type (Talos or K3s) and provides health summary
 #
-set -euo pipefail
+# Status tool: do NOT use -e/pipefail — a single failing probe must not abort
+# the whole report (and `… | head` SIGPIPE under pipefail yields false negatives).
+set -u
 
 # =============================================================================
 # Configuration
@@ -74,6 +76,14 @@ detect_cluster_type() {
     # Check if control plane is reachable
     if ! check_reachable "$CONTROL_PLANE_IP"; then
         log_error "Control plane ($CONTROL_PLANE_IP) is not reachable"
+        log_warn "Node reachability (control plane down — limited info):"
+        for ip in "${ALL_NODE_IPS[@]}"; do
+            if check_reachable "$ip"; then
+                echo -e "  $ip: ${GREEN}reachable${NC}"
+            else
+                echo -e "  $ip: ${RED}unreachable${NC}"
+            fi
+        done
         exit 1
     fi
 
@@ -312,7 +322,7 @@ get_kubernetes_status() {
 
     # Recent events
     print_section "Recent Warning Events (last 10)"
-    kubectl get events -A --field-selector type=Warning --sort-by='.lastTimestamp' 2>/dev/null | tail -11 | head -10 || echo "  No warning events"
+    kubectl get events -A --field-selector type=Warning --sort-by='.lastTimestamp' --no-headers 2>/dev/null | tail -10 || echo "  No warning events"
 }
 
 # =============================================================================

--- a/scripts/wipe-cluster.sh
+++ b/scripts/wipe-cluster.sh
@@ -23,11 +23,11 @@ if [[ -f "${PROJECT_DIR}/.env" ]]; then
 fi
 
 # BMC Configuration
-BMC_IP="${BMC_IP:-10.10.88.70}"
+BMC_HOST="${BMC_HOST:-10.10.88.70}"
 BMC_USER="${BMC_USER:-root}"
 
 # TPI CLI Configuration (for local tpi commands)
-export TPI_HOSTNAME="${TPI_HOSTNAME:-$BMC_IP}"
+export TPI_HOSTNAME="${TPI_HOSTNAME:-$BMC_HOST}"
 # TPI_USERNAME and TPI_PASSWORD should be set in environment if needed
 
 # Node Configuration
@@ -230,7 +230,7 @@ wipe_nvme_ssh() {
 
     log_info "Wiping NVMe on node $node_num ($ip)..."
 
-    ssh -o ConnectTimeout=10 "$SSH_USER@$ip" "
+    if ssh -o ConnectTimeout=10 "$SSH_USER@$ip" "
         set -e
         if [ -b $NVME_DEVICE ]; then
             # Unmount any mounted partitions
@@ -261,8 +261,7 @@ wipe_nvme_ssh() {
         else
             echo '  NVMe device not found, skipping'
         fi
-    " 2>/dev/null; local rc=$?
-    if [[ $rc -eq 0 ]]; then
+    " 2>/dev/null; then
         log_success "Node $node_num NVMe wiped"
     else
         log_warn "Node $node_num NVMe wipe may have failed"
@@ -275,7 +274,7 @@ wipe_emmc_ssh() {
 
     log_info "Wiping eMMC on node $node_num ($ip)..."
 
-    ssh -o ConnectTimeout=10 "$SSH_USER@$ip" "
+    if ssh -o ConnectTimeout=10 "$SSH_USER@$ip" "
         set -e
         if [ -b $EMMC_DEVICE ]; then
             echo '  WARNING: Wiping eMMC will remove the operating system!'
@@ -304,8 +303,7 @@ wipe_emmc_ssh() {
         else
             echo '  eMMC device not found, skipping'
         fi
-    " 2>/dev/null; local rc=$?
-    if [[ $rc -eq 0 ]]; then
+    " 2>/dev/null; then
         log_success "Node $node_num eMMC wiped"
     else
         log_warn "Node $node_num eMMC wipe may have failed"
@@ -324,6 +322,7 @@ wipe_talos_node() {
         --reboot=false \
         --system-labels-to-wipe STATE \
         --system-labels-to-wipe EPHEMERAL \
+        --user-disks-to-wipe "$NVME_DEVICE" \
         2>/dev/null; then
         log_success "Node $node_num Talos reset complete"
     else
@@ -371,15 +370,15 @@ cmd_status() {
 
     # BMC status
     print_section "BMC Status"
-    if check_reachable "$BMC_IP"; then
-        log_success "BMC ($BMC_IP) is reachable"
+    if check_reachable "$BMC_HOST"; then
+        log_success "BMC ($BMC_HOST) is reachable"
         if command -v tpi &>/dev/null; then
             echo ""
             echo "Power Status:"
             tpi power status 2>/dev/null || echo "  Unable to query"
         fi
     else
-        log_warn "BMC ($BMC_IP) is not reachable"
+        log_warn "BMC ($BMC_HOST) is not reachable"
     fi
 }
 
@@ -410,7 +409,7 @@ cmd_wipe_nvme() {
                 wipe_nvme_ssh "$ip" "$node_num"
                 ;;
             talos)
-                log_warn "Node $node_num: Use 'wipe talos' for Talos nodes (includes NVMe)"
+                log_warn "Node $node_num: Use 'wipe talos' for Talos nodes (resets system partitions + wipes NVMe)"
                 ;;
             talos-maintenance)
                 log_warn "Node $node_num in maintenance mode - reflash via BMC to wipe"
@@ -721,9 +720,9 @@ Storage Targets:
   emmc    /dev/mmcblk0  - eMMC flash (boot drive, OS)
 
 Environment Variables:
-  BMC_IP          BMC IP address (default: 10.10.88.70)
+  BMC_HOST          BMC IP address (default: 10.10.88.70)
   SSH_USER        SSH user for Armbian nodes (default: root)
-  TPI_HOSTNAME    TPI target host (default: BMC_IP)
+  TPI_HOSTNAME    TPI target host (default: BMC_HOST)
   TPI_USERNAME    TPI authentication username
   TPI_PASSWORD    TPI authentication password
 


### PR DESCRIPTION
Remediates the **high-value** findings from a full audit of `scripts/`. `shellcheck` + `bash -n` pass on all five scripts. (CI's `Lint`/`CodeQL` don't actually lint shell, so local shellcheck is the substantive gate.)

## Data-loss / safety
- **`setup-k3s-node.sh` — refuse to format a non-empty NVMe.** The format was gated only by mount-state, so an unmounted-but-populated `/dev/nvme0n1` would be `wipefs`+`mkfs.xfs -f`'d on re-run, destroying ~500 GB of Longhorn data. Now refuses if a filesystem is present and not mounted at `/var/lib/longhorn` (override `FORCE_WIPE=1`).
- **`wipe-cluster.sh` — `wipe talos` now actually wipes the NVMe** (`--user-disks-to-wipe`); the message no longer falsely claims the STATE/EPHEMERAL reset "includes NVMe" (it didn't → stale Longhorn data survived a "wipe").

## Reliability
- **`setup-k3s-node.sh`** — fstab gets `nofail,x-systemd.device-timeout` (headless boot no longer drops to emergency shell if the NVMe is missing), `sleep 2` → `partprobe + udevadm settle`, non-empty-UUID guard, idempotent fstab entry.
- **`wipe-cluster.sh`** — fixed `ssh …; local rc=$?` under `set -e`: the `else`/warn branch was dead and a mid-wipe `ssh` failure aborted the run, leaving a **half-wiped fleet**. Now `if ssh …; then … else … fi` (warn-and-continue works).
- **`deploy-k3s-cluster.sh`** — `set -eo pipefail` inside the remote heredocs so a failed `curl | sh` is detected instead of silently no-opping; fixed `sleep 30` → readiness poll (`node-token` + `/readyz`); `--tls-san=$SERVER_IP` instead of a hardcoded IP (kept the cert SAN from breaking if `SERVER_IP` changes).
- **`talos-cluster-status.sh`** — dropped `-e`/`pipefail` (kept `-u`): a status tool shouldn't abort on one failed probe, and `… | head` SIGPIPE under `pipefail` produced false negatives; control-plane-down now prints a node reachability table instead of nothing; "last 10 warning events" keeps the **newest** 10 (was `tail -11 | head -10`).

## Secret hygiene / consistency
- **`.gitignore`** — added `cluster-config/*-patched.yaml`: the deploy script's real applied configs (with cluster secrets) were neither tracked nor ignored, so a `git add -A` could leak them. *(No secrets are currently committed — verified.)*
- **`deploy-talos-cluster.sh`** — `reset` now deletes only generated artifacts (`controlplane.yaml`, `worker.yaml`, `*-patched.yaml`), not hand-authored `*-patch.yaml` / `*-simple.yaml` / `*.example.yaml`.
- **`wipe-cluster.sh`** — standardized on `BMC_HOST` (was `BMC_IP`), so the `BMC_HOST` override documented in `.env.example` actually applies here too.

## Set flags hardened
`set -e` → `set -euo pipefail` on `setup-k3s-node.sh` and `deploy-k3s-cluster.sh`.

## Deferred (need real-hardware testing — intentionally not blind-edited)
- `deploy-talos-cluster.sh` etcd-bootstrap **readiness/idempotency** (it probes the `--insecure`/maintenance API and the run-once guard fails open) — changing a run-once etcd path untested is riskier than the current behavior.
- `controlplane.yaml`/`worker.yaml` tracked-template **overwrite hazard** (deploy overwrites the tracked sanitized templates with real-secret versions). Proper fix is the rename-to-`.example` pattern already applied to `controlplane-node1`; deferred to a focused follow-up.
