### PR TITLE
docs: correct Talos NPU/GPU support status + README stale items

### DIFF
--- a/CLUSTER_PLAN.md
+++ b/CLUSTER_PLAN.md
@@ -332,8 +332,13 @@ kubectl patch storageclass longhorn -p '{"metadata": {"annotations":{"storagecla
 
 ### Current State
 
-The RK3588 NPU requires:
-1. **Kernel driver** (`rknpu` module) - Must be compiled into/loaded by the kernel
+The RK3588 NPU has two distinct, incompatible driver stacks:
+
+- **Proprietary `rknpu` + RKNN SDK** (this repo's `repo/rknn-toolkit2`, `repo/rknn-llm`) - the full stack incl. RKLLM. Requires the BSP kernel, so **K3s/Armbian only** (not available on Talos).
+- **Mainline open `rocket` driver** (Linux 6.18) - loadable on Talos via the contrib `siderolabs/rockchip-rknn` extension (already in `talos-schematic.yaml`), exposing `/dev/accel/accel0`. Userspace is Mesa Teflon (TFLite) - small CNNs only, **no RKLLM**.
+
+For the RKNN/RKLLM workloads below (the proprietary stack), you need:
+1. **Kernel driver** (`rknpu` module) - BSP kernel (K3s/Armbian)
 2. **Runtime libraries** (`librknnrt.so`) - Available in `repo/rknn-toolkit2/`
 3. **Kubernetes device plugin** - For NPU scheduling
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A 4-node bare-metal Kubernetes cluster built on Turing RK1 compute modules, supp
 
 | Distribution | Best For | NPU/GPU | Shell Access |
 |--------------|----------|---------|--------------|
-| **[Talos Linux](docs/INSTALLATION.md)** | Production, Security | No | API only |
+| **[Talos Linux](docs/INSTALLATION.md)** | Production, Security | Partial | API only |
 | **[K3s on Armbian](docs/INSTALLATION-K3S.md)** | Development, AI/ML | **Yes** | SSH |
 
 See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
@@ -101,7 +101,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 | Component | Version | Notes |
 |-----------|---------|-------|
 | Talos Linux | v1.13.5 | Immutable, API-driven Kubernetes OS |
-| Linux Kernel | 6.12.62 | Mainline kernel (ARM64) |
+| Linux Kernel | 6.18.36 | Mainline kernel (ARM64) |
 
 ### Kubernetes Components
 
@@ -199,28 +199,32 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 
 ## Limitations & Known Issues
 
-### NPU Not Available (Talos Only)
+### NPU: Partial on Talos, Full on K3s
 
-| Issue | Status | Details |
+| Capability | Status | Details |
 |-------|--------|---------|
-| RK3588 NPU inaccessible | **Talos: Not Supported** | Talos uses mainline Linux kernel which lacks Rockchip's proprietary RKNPU driver |
-| | **K3s/Armbian: Supported** | BSP kernel includes full NPU support |
+| RK3588 NPU driver | **Talos: Partial** | The mainline open-source `rocket` driver loads via the contrib `siderolabs/rockchip-rknn` extension (Talos 1.13 / Linux 6.18), exposing `/dev/accel/accel0` |
+| RKNN SDK / RKLLM | **Talos: Not supported** | `librknnrt` / `rknn-toolkit2` / RKLLM require Rockchip's proprietary `rknpu` BSP driver, which is *not* the mainline `rocket` driver |
+| Either NPU stack | **K3s/Armbian: Supported** | BSP kernel + RKNN SDK provide full NPU support, including LLMs |
 
-**Impact:** On Talos, the 6 TOPS NPU in each RK3588 cannot be used for hardware-accelerated AI inference.
+**Impact:** On Talos the NPU driver is now available, but only the open Mesa **Teflon** (TFLite) path works - limited to MobileNet-class CNNs, effectively single-core, and **no LLM (RKLLM) support**. The full RKNN/RKLLM stack this repo vendors (`repo/rknn-llm`, `repo/rknn-toolkit2`) runs on the **K3s/Armbian** path only.
 
 **Solutions:**
-1. **Use K3s on Armbian** - Full NPU support with RKNN SDK (see [docs/INSTALLATION-K3S.md](docs/INSTALLATION-K3S.md))
-2. Use CPU-based inference on Talos (ONNX Runtime, TensorFlow Lite)
-3. Wait for mainline NPU driver (in kernel review)
+1. **Run RKNN/RKLLM workloads on K3s on Armbian** - full NPU support with the RKNN SDK (see [docs/INSTALLATION-K3S.md](docs/INSTALLATION-K3S.md))
+2. **On Talos**, use the open `rocket`/Teflon path for small CNNs, or CPU-based inference (ONNX Runtime, TensorFlow Lite)
 
-### GPU Not Available (Talos Only)
+> **Note:** the `rocket` driver only binds if the RK1 device tree enables the NPU node - verify on hardware with `ls /dev/accel/` and `dmesg | grep -i rocket` after applying the extension.
 
-| Issue | Status | Details |
+### GPU: Partial on Talos, Full on K3s
+
+| Capability | Status | Details |
 |-------|--------|---------|
-| Mali-G610 GPU inaccessible | **Talos: Not Supported** | No GPU driver/passthrough in Talos |
-| | **K3s/Armbian: Supported** | OpenCL and Vulkan available |
+| Mali-G610 GPU driver | **Talos: Partial** | The `panthor` driver loads via the contrib `siderolabs/panfrost` extension (OpenGL ES / Vulkan); no proprietary Mali blob, limited OpenCL, no device plugin |
+| | **K3s/Armbian: Supported** | BSP userspace provides OpenCL and Vulkan |
 
-**Impact:** On Talos, no GPU acceleration for graphics or compute workloads. K3s on Armbian provides full GPU support.
+**Impact:** On Talos the open `panthor` driver enables OpenGL ES/Vulkan, but not the proprietary OpenCL stack. K3s on Armbian provides full GPU support.
+
+> **Note:** the RK3588 GPU and NPU are integrated SoC blocks - PCIe/VFIO "passthrough" does not apply. The model is a host-kernel driver plus exposing `/dev/dri/renderD128` (GPU) or `/dev/accel/accel0` (NPU) into a container (CDI is enabled by default in Talos 1.13).
 
 ### Storage Limitations
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,8 +291,8 @@ flowchart TB
     subgraph RK1["Turing RK1 Module (x4)"]
         subgraph SoC["Rockchip RK3588"]
             CPU["CPU<br/>4x A76 @ 2.4GHz<br/>4x A55 @ 1.8GHz"]
-            GPU["GPU<br/>Mali-G610 MP4<br/>(Not Available)"]
-            NPU["NPU<br/>6 TOPS INT8<br/>(Not Available)"]
+            GPU["GPU<br/>Mali-G610 MP4<br/>(Talos: partial / K3s: full)"]
+            NPU["NPU<br/>6 TOPS INT8<br/>(Talos: partial / K3s: full)"]
         end
 
         RAM["RAM<br/>16GB/32GB<br/>LPDDR4X"]

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -51,8 +51,8 @@ This document provides a comprehensive comparison between the two Kubernetes dis
 | **RAM** | Full support | Full support |
 | **eMMC Boot** | Supported | Supported |
 | **NVMe Storage** | Supported | Supported |
-| **NPU (6 TOPS)** | Not available | **Supported** |
-| **GPU (Mali-G610)** | Not available | **Supported** |
+| **NPU (6 TOPS)** | Partial (open `rocket` driver) | **Supported** |
+| **GPU (Mali-G610)** | Partial (`panthor` driver) | **Supported** |
 | **Hardware Video Decode** | Not available | **Supported** |
 
 ### NPU/AI Hardware Access
@@ -61,10 +61,12 @@ This document provides a comprehensive comparison between the two Kubernetes dis
 |------------|-------------|----------------|
 | **RKNN Runtime** | Not supported | **Full support** |
 | **RKLLM (LLM inference)** | Not supported | **Full support** |
-| **6 TOPS INT8** | Not available | **Available** |
+| **6 TOPS INT8** | Partial (CNNs via Mesa Teflon) | **Available** |
 | **Model Conversion** | Not supported | **Supported** |
 | **Hardware Video Encode** | Not available | **Supported** |
-| **OpenCL** | Not available | **Supported** |
+| **OpenCL** | Limited (Mesa rusticl, experimental) | **Supported** |
+
+> On Talos, the NPU/GPU **drivers** are available (open `rocket` / `panthor` via contrib extensions), but the proprietary **RKNN/RKLLM SDK** and **OpenCL blob** are not - those remain exclusive to the K3s/Armbian BSP. See the README "Limitations" section for details.
 
 ### Management
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -118,7 +118,7 @@ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 - RAM: 16GB or 32GB
 - eMMC: 32GB (system disk - /dev/mmcblk0)
 - NVMe: 500GB Crucial P3 (data disk - /dev/nvme0n1)
-- NPU: 6 TOPS (not currently supported in Talos)
+- NPU: 6 TOPS (3-core) - partial on Talos via the mainline open `rocket` driver (`siderolabs/rockchip-rknn` extension, small CNNs only); the full RKNN/RKLLM SDK is K3s/Armbian-only
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,8 @@ Choose your preferred Kubernetes distribution:
 |---------|-------|----------------|
 | Shell Access | No (API only) | Yes (SSH) |
 | Security | Hardened by default | Manual hardening |
-| **NPU (6 TOPS)** | Not available | **Supported** |
-| **GPU (Mali-G610)** | Not available | **Supported** |
+| **NPU (6 TOPS)** | Partial (open `rocket` driver; no RKLLM) | **Supported** |
+| **GPU (Mali-G610)** | Partial (`panthor` driver) | **Supported** |
 | Debugging | talosctl | Standard Linux |
 | Updates | Atomic | apt + reinstall |
 | Learning Curve | Steeper | Gentler |

--- a/talos-schematic.yaml
+++ b/talos-schematic.yaml
@@ -5,5 +5,7 @@ customization:
   systemExtensions:
     officialExtensions:
       - siderolabs/iscsi-tools
+      # rockchip-rknn ships the mainline open 'rocket' NPU driver (Linux 6.18),
+      # not the proprietary rknpu; RKNN SDK / RKLLM remain K3s/Armbian-only.
       - siderolabs/rockchip-rknn
       - siderolabs/util-linux-tools


### PR DESCRIPTION
Corrects the now-inaccurate "NPU/GPU not supported in Talos" docs and cleans up stale items in the root README. Docs-only; `yamllint` + `markdownlint` pass.

## Why
Researching the current state (2026) found that the `siderolabs/rockchip-rknn` extension added in #36 ships the **mainline open-source `rocket` NPU driver** (Linux 6.18, `/dev/accel/accel0`) — **not** Rockchip's proprietary `rknpu`. So "NPU not supported in Talos" is outdated, but "supported" would also mislead:

- **NPU driver on Talos:** now available (open `rocket` via contrib extension) — but userspace is **Mesa Teflon (TFLite)**: small CNNs only, ~single-core, **no LLMs**.
- **RKNN SDK / RKLLM** (this repo's `repo/rknn-llm`, `repo/rknn-toolkit2`): **still K3s/Armbian-only** — they need the proprietary `rknpu` BSP driver, which `rocket` is not.
- **GPU:** `panthor` (Mali-G610) loads via the `panfrost` extension (GL ES/Vulkan); no proprietary blob/OpenCL parity, no device plugin.

## Changes
- **NPU/GPU status → "Partial" on Talos** across `README.md`, `docs/COMPARISON.md`, `docs/README.md`, `docs/ARCHITECTURE.md`, `docs/INSTALLATION.md`. The `RKNN Runtime` / `RKLLM` rows stay **"Talos: Not supported"** (accurate).
- **Dropped "passthrough" framing** — RK3588's GPU/NPU are integrated SoC blocks; the model is host-kernel driver + `/dev` exposure (CDI is on by default in Talos 1.13).
- **`CLUSTER_PLAN.md` Phase 6** now documents the two distinct, incompatible NPU driver stacks (proprietary `rknpu`/RKNN vs mainline `rocket`/Teflon).
- **`talos-schematic.yaml`** gets a clarifying comment (kept the extension per the decision to document, not drop). The comment is inert — **schematic ID unchanged** (`35d07e8c…`), so #36's image URLs remain valid.
- **Caveat documented:** the `rocket` driver only binds if the RK1 device tree enables the NPU node — unverified on this hardware; check with `ls /dev/accel/` + `dmesg | grep -i rocket`.

## README stale-item cleanup
- "Choose Your Distribution" table: Talos NPU/GPU **`No` → `Partial`**.
- **Linux kernel `6.12.62` → `6.18.36`** — `6.12.62` was the pre-bump v1.11 kernel; Talos v1.13.5 ships 6.18.36 (verified against the release notes; this is also what makes the `rocket` driver available).

## Not changed (intentionally)
RKNN/RKLLM/Model-Conversion rows remain "Talos: Not supported" — that's correct; only the *driver/hardware* availability moved to "Partial".
