### PR TITLE
chore(release): finalize CHANGELOG for v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-23
+
 ### Added
 
+- **freed-dev-llc Turing Pi branding system** — horizontal banner logo, square favicon icon, cross-repo buttons, and a rebranded social-preview image (Configuration theme) (#34, #37).
+- **`siderolabs/rockchip-rknn` NPU system extension** added to the Talos image schematic — ships the mainline open `rocket` NPU driver (Linux 6.18) (#36).
+- `docs/HARDWARE-TEST-PLAN.md` — phased plan to validate the cluster on real RK1 hardware (#42).
 - `.editorconfig` to keep formatting consistent across editors.
 - `.github/CODEOWNERS` matching the pattern used by sister freed-dev-llc repos.
 - This `CHANGELOG.md`.
@@ -26,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - STORAGE.md hostnames switched from auto-generated `talos-0ow-v7t`-style IDs to `turing-w1/w2/w3` to match the documented hostname patch (#23).
 - INSTALLATION storage table corrected — Node 1 control plane has no NVMe by design (#23).
 - `docs/README.md` scripts table now lists `deploy-talos-cluster.sh` and `talos-cluster-status.sh` (#23).
+- CI/Dependabot: PAT-based auto-approve/merge with a semver-major guard (#29), then switched to the org reusable auto-merge workflow (#30).
+- Dependency bumps: `actions/checkout` → v7.0.0 (#31, #33), plus `actions/setup-python`, `markdownlint-cli2-action`, and submodules `repo/rknn-llm` (#32) / `repo/sbc-rockchip`.
+- Talos NPU/GPU docs corrected from "not supported" to **Partial** — the open `rocket` (NPU) and `panthor` (GPU) drivers load via contrib extensions, while the proprietary RKNN/RKLLM SDK remains K3s/Armbian-only; dropped the inaccurate PCIe "passthrough" framing (#41).
+- README: "Choose Your Distribution" NPU/GPU column → "Partial"; Linux kernel `6.12.62` → `6.18.36` (the actual Talos v1.13.5 kernel) (#41).
 
 ### Fixed
 
@@ -38,3 +47,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/INSTALLATION-K3S.md` K3s Ref table NGINX Ingress `v1.12.x` → `v1.13.x` (#27).
 - README License section body still said "MIT license" even after #25 fixed the badge; now says "Apache 2.0 license (see LICENSE)" (#27).
 - MetalLB pool YAML snippets at `docs/INSTALLATION.md:732` and `docs/INSTALLATION-K3S.md:604` still used `10.10.88.80-10.10.88.99` (full-range form); reconciled to `80-89` to match the table form and the ground-truth `cluster-config/metallb-config.yaml` (#27).
+- **Config audit (#36):** the `.gitignore` secret-guard for the control-plane node config was illusory (a tracked sanitized copy defeated it) — renamed to `controlplane-node1.example.yaml` and tightened the ignore glob; stale `images/latest_link.txt` pointing at Talos `v1.11.6` → `v1.13.5`; dead `BMC_IP` → `BMC_HOST` in `.env.example`.
+- **Script hardening (#38):** `setup-k3s-node.sh` refuses to format a populated NVMe (data-loss guard) and adds fstab `nofail`; `wipe-cluster.sh` fixed `ssh`-under-`set -e` (no more half-wiped fleet), now wipes the NVMe on Talos resets, and uses `BMC_HOST`; `deploy-k3s-cluster.sh` polls for readiness, derives the TLS SAN, and detects failed remote installs; `talos-cluster-status.sh` no longer aborts on one failed probe; gitignored `cluster-config/*-patched.yaml`; narrowed the `reset` glob.


### PR DESCRIPTION
Prepares the **v1.2.0** release. Moves the `[Unreleased]` backlog into `[1.2.0] - 2026-06-23` and documents the merged work since v1.1.1 that wasn't yet in the changelog (#29–#42): the branding system (#34, #37), the `rockchip-rknn` NPU extension (#36), the hardware test plan (#42), CI/dependabot changes (#29–#33), NPU/GPU doc corrections (#41), config-audit fixes (#36), and script hardening (#38). The Talos v1.13.5 / K8s v1.35.0 work (#28, #35) was already recorded.

After merge: tag `v1.2.0` on `main` and cut the GitHub release from this changelog section.