### PR TITLE
fix(deploy): harden deploy-talos for real RK1 / Talos v1.13 (hardware-found bugs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`deploy-talos-cluster.sh` hardened for real RK1 / Talos v1.13 deploys** (found and validated end-to-end on the 4-node hardware):
+  - Pin Kubernetes via `--kubernetes-version` (default `K8S_VERSION=v1.35.0`) — the script previously deployed Talos's default (v1.36.2), not the repo's intended version ([#47](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/47)).
+  - Set `machine.install.image` to the Factory **schematic** installer (`factory.talos.dev/installer/<SCHEMATIC_ID>:<version>`) so the `sbc-rockchip` overlay + `rockchip-rknn` NPU extension survive `talosctl upgrade` (was the plain `ghcr.io/siderolabs/installer`) ([#45](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/45)).
+  - Stage the flash image on the BMC microSD (`/mnt/sdcard`; override `BMC_IMAGE_PATH`) instead of `/tmp` — the Turing Pi 2 BMC's `/tmp` is a ~58 MB tmpfs that cannot hold the 2.2 GB image ([#44](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/44)).
+  - Bootstrap now polls the **secure** API (a configured node stops serving the insecure API), guards on real etcd membership (`get etcdmembers`), and retries until etcd is ready ([#39](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/39)).
+- **`cluster-config/*-patch.yaml`**: drop the legacy `machine.network.hostname` — on Talos v1.13 it conflicts with the `HostnameConfig` document and fails `talosctl validate` ([#46](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/46)).
+
 ## [1.2.0] - 2026-06-23
 
 ### Added

--- a/cluster-config/controlplane-patch.yaml
+++ b/cluster-config/controlplane-patch.yaml
@@ -1,6 +1,9 @@
 machine:
   network:
-    hostname: turing-cp1
+    # Talos v1.13 manages the hostname via a separate HostnameConfig document
+    # (auto: stable). Setting machine.network.hostname here conflicts with it and
+    # fails validation ("static hostname is already set in v1alpha1 config"). For a
+    # static name, edit the HostnameConfig document in the generated config instead.
     interfaces:
       - interface: eth0
         dhcp: true

--- a/cluster-config/worker1-patch.yaml
+++ b/cluster-config/worker1-patch.yaml
@@ -1,6 +1,5 @@
 machine:
   network:
-    hostname: turing-w1
     interfaces:
       - interface: eth0
         dhcp: true

--- a/cluster-config/worker2-patch.yaml
+++ b/cluster-config/worker2-patch.yaml
@@ -1,6 +1,5 @@
 machine:
   network:
-    hostname: turing-w1
     interfaces:
       - interface: eth0
         dhcp: true

--- a/cluster-config/worker3-patch.yaml
+++ b/cluster-config/worker3-patch.yaml
@@ -1,6 +1,5 @@
 machine:
   network:
-    hostname: turing-w2
     interfaces:
       - interface: eth0
         dhcp: true

--- a/cluster-config/worker4-patch.yaml
+++ b/cluster-config/worker4-patch.yaml
@@ -1,6 +1,5 @@
 machine:
   network:
-    hostname: turing-w3
     interfaces:
       - interface: eth0
         dhcp: true

--- a/scripts/deploy-talos-cluster.sh
+++ b/scripts/deploy-talos-cluster.sh
@@ -23,6 +23,11 @@ fi
 IMAGE_DIR="${PROJECT_DIR}/images/latest"
 TALOS_IMAGE="${IMAGE_DIR}/metal-arm64.raw"
 TALOS_VERSION="v1.13.5"
+K8S_VERSION="${K8S_VERSION:-v1.35.0}"
+# Factory schematic ID for the RK1 image (sbc-rockchip overlay + rockchip-rknn NPU +
+# iscsi-tools + util-linux-tools). Used as the install image so the board overlay and
+# extensions survive `talosctl upgrade` (the plain ghcr installer would drop them).
+SCHEMATIC_ID="${SCHEMATIC_ID:-35d07e8c5e698ec18c7356eded0849b477585f45454d86a52b4e0b87e2e543ec}"
 
 # Network configuration
 BMC_HOST="${BMC_HOST:-10.10.88.70}"
@@ -101,10 +106,18 @@ wait_for_node() {
 wait_for_talos_api() {
     local ip=$1
     local timeout=${2:-$BOOT_TIMEOUT}
+    # mode: "insecure" = maintenance mode (pre-config); "secure" = configured node
+    # (e.g. before bootstrap — a configured node no longer serves the insecure API).
+    local mode=${3:-insecure}
     local elapsed=0
 
-    log_info "Waiting for Talos API on $ip (timeout: ${timeout}s)..."
-    while ! talosctl --nodes "$ip" version --insecure &>/dev/null 2>&1; do
+    log_info "Waiting for Talos API on $ip ($mode, timeout: ${timeout}s)..."
+    while true; do
+        if [ "$mode" = "secure" ]; then
+            talosctl --nodes "$ip" version &>/dev/null && break
+        else
+            talosctl --nodes "$ip" version --insecure &>/dev/null && break
+        fi
         sleep 5
         elapsed=$((elapsed + 5))
         if [ "$elapsed" -ge "$timeout" ]; then
@@ -302,7 +315,9 @@ flash_nodes() {
     fi
 
     # Check image on BMC or copy it
-    local bmc_image_path="/tmp/metal-arm64.raw"
+    # The Turing Pi 2 BMC's /tmp is a tiny tmpfs (~58MB) — far too small for the ~2.2GB
+    # image. Stage it on the microSD (/mnt/sdcard) instead. Override with BMC_IMAGE_PATH.
+    local bmc_image_path="${BMC_IMAGE_PATH:-/mnt/sdcard/metal-arm64.raw}"
 
     log_info "The image needs to be accessible from the BMC."
     echo "Options:"
@@ -396,6 +411,8 @@ generate_configs() {
         "$CLUSTER_NAME" \
         "$KUBERNETES_ENDPOINT" \
         --install-disk /dev/mmcblk0 \
+        --install-image "factory.talos.dev/installer/${SCHEMATIC_ID}:${TALOS_VERSION}" \
+        --kubernetes-version "$K8S_VERSION" \
         --output-dir . \
         --force
 
@@ -422,7 +439,8 @@ create_worker_patches() {
             cat > "$patch_file" << EOF
 machine:
   network:
-    hostname: turing-w${worker_num}
+    # Do not set machine.network.hostname on Talos v1.13 — it conflicts with the
+    # HostnameConfig document and fails validation. Hostname stays auto (stable).
     interfaces:
       - interface: eth0
         dhcp: true
@@ -560,30 +578,40 @@ bootstrap_cluster() {
 
     setup_talosctl
 
-    # Wait for control plane to be ready
+    # Wait for the control plane's SECURE API. After apply-config the node leaves
+    # maintenance mode and no longer answers the insecure API, so an --insecure probe
+    # would loop until timeout.
     log_info "Waiting for control plane Talos API..."
-    wait_for_talos_api "$CONTROL_PLANE_IP" 300 || {
+    wait_for_talos_api "$CONTROL_PLANE_IP" 300 secure || {
         log_error "Control plane not ready for bootstrap"
         return 1
     }
 
-    # Check if already bootstrapped
-    if talosctl --nodes "$CONTROL_PLANE_IP" get members &>/dev/null 2>&1; then
-        log_warn "Cluster appears to be already bootstrapped"
+    # Already-bootstrapped guard: query actual etcd membership. Only a SUCCESSFUL query
+    # means bootstrapped — a failure means the API/etcd isn't reachable yet (do not skip).
+    # (`get members` is cluster-discovery state and returns entries even before bootstrap,
+    # so it is not a reliable guard.)
+    if talosctl --nodes "$CONTROL_PLANE_IP" get etcdmembers &>/dev/null 2>&1; then
+        log_warn "etcd already reports members; cluster appears bootstrapped"
         if ! confirm "Bootstrap anyway? (This can break the cluster if already running)"; then
             log_info "Skipping bootstrap"
             return 0
         fi
     fi
 
-    # Bootstrap
+    # Bootstrap. etcd may not be ready the instant the API comes up (it waits for the
+    # container runtime + volumes), so retry until it succeeds.
     log_info "Bootstrapping cluster (this runs ONCE)..."
-    if talosctl bootstrap --nodes "$CONTROL_PLANE_IP"; then
-        log_success "Bootstrap initiated"
-    else
-        log_error "Bootstrap failed"
-        return 1
-    fi
+    local b_elapsed=0
+    until talosctl bootstrap --nodes "$CONTROL_PLANE_IP" 2>/dev/null; do
+        sleep 5
+        b_elapsed=$((b_elapsed + 5))
+        if [ "$b_elapsed" -ge 120 ]; then
+            log_error "Bootstrap failed (etcd not ready after 120s)"
+            return 1
+        fi
+    done
+    log_success "Bootstrap initiated"
 
     # Wait for bootstrap to complete
     log_info "Waiting for Kubernetes API to become available..."


### PR DESCRIPTION
Hardens `deploy-talos-cluster.sh` + the `cluster-config/*-patch.yaml` patches for real RK1 / Talos v1.13 deployments. **Every fix was found and validated end-to-end on the actual 4-node RK1 cluster** (Talos v1.13.5 + K8s v1.35.0; NPU `rocket` driver bound on all nodes; `/dev/accel/accel0` present).

## Fixes
| Issue | Bug | Fix |
|---|---|---|
| #47 | Deployed Talos's default K8s (v1.36.2), not the repo's v1.35.0 | `--kubernetes-version` (`K8S_VERSION`, default `v1.35.0`) |
| #45 | `install.image` = plain installer → drops overlay/NPU on `talosctl upgrade` | Factory **schematic** installer (`SCHEMATIC_ID`) |
| #44 | Flash `scp`s 2.2 GB to BMC `/tmp` (58 MB tmpfs) → fails | Stage on `/mnt/sdcard` (override `BMC_IMAGE_PATH`) |
| #39 | Bootstrap waits on `--insecure` API → blocks 300 s on a configured node; guard fails open | Secure-API wait + `get etcdmembers` guard + retry-until-ready |
| #46 | Patches set legacy `machine.network.hostname` → fails Talos v1.13 validation | Drop it (`HostnameConfig` owns hostname on v1.13) |

## Validation
- `shellcheck` + `bash -n` pass.
- `talosctl gen config` with the new flags → `install.image: factory.talos.dev/installer/35d07e8c…:v1.13.5`, `kube-apiserver:v1.35.0`; the fixed `controlplane-patch.yaml` patches and **validates for metal mode**.
- These exact corrected approaches were used in the manual deploy that brought up the validated 4-node cluster.

## Out of scope (tracked separately)
- #40 — tracked `controlplane.yaml`/`worker.yaml` templates are stage-able with real secrets (needs the `.example` rename). Not included here.

Fixes #39, #44, #45, #46, #47.
