### PR TITLE
fix(wipe): reset each Talos node via its own endpoint (worker resets fail after CP reset)

### DIFF
--- a/scripts/wipe-cluster.sh
+++ b/scripts/wipe-cluster.sh
@@ -316,8 +316,10 @@ wipe_talos_node() {
 
     log_info "Resetting Talos node $node_num ($ip)..."
 
-    # Use talosctl reset to wipe the node
-    if talosctl --nodes "$ip" reset \
+    # Use talosctl reset to wipe the node. Target the node's OWN endpoint so the
+    # reset does not proxy through the control-plane endpoint (which is itself being
+    # reset in this loop) — otherwise worker resets fail once the CP is gone.
+    if talosctl --nodes "$ip" --endpoints "$ip" reset \
         --graceful=false \
         --reboot=false \
         --system-labels-to-wipe STATE \


### PR DESCRIPTION
`wipe_talos_node` ran `talosctl --nodes $ip reset` without `--endpoints`, so resets proxied through the talosconfig endpoint (the control plane). The wipe resets the CP first → that endpoint disappears → all worker resets fail (misleadingly logged as "may already be wiped").

**Found on real hardware (2026-06-23):** `[✓] Node 1 reset complete` then `[!] Node 2/3/4 reset failed`; a direct `talosctl --nodes 10.10.88.74 --endpoints 10.10.88.74 reset …` succeeded (rc=0).

**Fix:** target each node's own endpoint (`--endpoints $ip`). shellcheck + bash -n pass.

Fixes #49.