### PR TITLE
docs: NPU verified on hardware + correct CP-NVMe claim (release v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-06-23
+
 ### Fixed
 
 - **`deploy-talos-cluster.sh` hardened for real RK1 / Talos v1.13 deploys** (found and validated end-to-end on the 4-node hardware):
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`cluster-config/*-patch.yaml`**: drop the legacy `machine.network.hostname` — on Talos v1.13 it conflicts with the `HostnameConfig` document and fails `talosctl validate` ([#46](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/46)).
 - **`wipe-cluster.sh`**: reset each Talos node via its own endpoint (`--endpoints $ip`) — resets previously proxied through the control-plane endpoint, so worker resets failed once the CP was reset ([#49](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/49)).
 - **`cluster-config/`**: renamed the tracked `controlplane.yaml` / `worker.yaml` to `*.example.yaml` (sanitized references) and gitignored the working names — `deploy-talos-cluster.sh generate` writes real cluster secrets to `controlplane.yaml` / `worker.yaml`, which were tracked and therefore stage-able by `git add -A` ([#40](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/40)).
+- **Docs:** marked the Talos NPU `rocket` driver binding as **verified on real hardware** (was an unverified caveat — `/dev/accel/accel0` confirmed on all 4 nodes); corrected the stale "control plane has no NVMe by design" claim — all 4 nodes have a 500GB NVMe and the control plane's is used for Longhorn (`allowSchedulingOnControlPlanes`); NVMe storage total `1.5TB` → `2TB`.
 
 ## [1.2.0] - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 | GPU | Mali-G610 MP4 |
 | NPU | 6 TOPS (INT8) - *see limitations* |
 | eMMC | 32GB (system disk) |
-| NVMe | 500GB Crucial P3 (worker nodes) |
+| NVMe | 500GB Crucial P3 (all 4 nodes) |
 
 ### Cluster Topology
 
@@ -78,7 +78,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 │   Node 1    │   Node 2    │   Node 3    │      Node 4       │
 │ Control Pl. │   Worker    │   Worker    │      Worker       │
 │ 10.10.88.73 │ 10.10.88.74 │ 10.10.88.75 │   10.10.88.76     │
-│   32GB eMMC │ 32GB + 500GB│ 32GB + 500GB│  32GB + 500GB     │
+│ 32GB + 500GB│ 32GB + 500GB│ 32GB + 500GB│  32GB + 500GB     │
 └─────────────┴─────────────┴─────────────┴───────────────────┘
 ```
 
@@ -89,7 +89,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 | CPU Cores | 32 (8 per node) |
 | RAM | 64-128GB |
 | Storage (eMMC) | 128GB |
-| Storage (NVMe) | 1.5TB |
+| Storage (NVMe) | 2TB (4x 500GB) |
 | Network | 4x 1Gbps |
 
 ---
@@ -158,7 +158,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 - Health monitoring and self-healing
 
 **Distributed Storage**
-- ~1.5TB distributed storage via Longhorn
+- ~2TB raw NVMe (4x 500GB) for distributed Longhorn storage
 - Volume replication across nodes (configurable 1-3 replicas)
 - Snapshots and backups
 - Dynamic volume provisioning
@@ -213,7 +213,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 1. **Run RKNN/RKLLM workloads on K3s on Armbian** - full NPU support with the RKNN SDK (see [docs/INSTALLATION-K3S.md](docs/INSTALLATION-K3S.md))
 2. **On Talos**, use the open `rocket`/Teflon path for small CNNs, or CPU-based inference (ONNX Runtime, TensorFlow Lite)
 
-> **Note:** the `rocket` driver only binds if the RK1 device tree enables the NPU node - verify on hardware with `ls /dev/accel/` and `dmesg | grep -i rocket` after applying the extension.
+> **Verified on real RK1 hardware (2026-06-23):** the `rocket` driver binds (kernel module Live) and `/dev/accel/accel0` is present on all 4 nodes running Talos v1.13.5 + the `rockchip-rknn` extension. Check with `talosctl get modules` / `talosctl list /dev/accel/`.
 
 ### GPU: Partial on Talos, Full on K3s
 
@@ -230,7 +230,7 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for detailed feature comparison.
 
 | Issue | Status | Details |
 |-------|--------|---------|
-| Control plane has no NVMe | By Design | Only workers have NVMe; CP uses eMMC only |
+| All 4 nodes have a 500GB NVMe | Info | The control plane is schedulable (`allowSchedulingOnControlPlanes`) and its NVMe is used for Longhorn, like the workers |
 | Single replica risk | Configurable | Default 3 replicas; 2-replica mode loses redundancy if node fails |
 
 ### Network Limitations

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -108,7 +108,7 @@ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 | Node | Role | Hostname | IP Address | Storage |
 |------|------|----------|------------|---------|
-| Node 1 | Control Plane | turing-cp1 | 10.10.88.73 | ~31GB eMMC usable (no NVMe by design) |
+| Node 1 | Control Plane | turing-cp1 | 10.10.88.73 | ~31GB eMMC + 500GB NVMe |
 | Node 2 | Worker | turing-w1 | 10.10.88.74 | ~31GB eMMC + 500GB NVMe |
 | Node 3 | Worker | turing-w2 | 10.10.88.75 | ~31GB eMMC + 500GB NVMe |
 | Node 4 | Worker | turing-w3 | 10.10.88.76 | ~31GB eMMC + 500GB NVMe |


### PR DESCRIPTION
Brings docs current after the hardware-validation session, and finalizes the **v1.2.1** CHANGELOG.

- **NPU:** README's `rocket`-binding note changed from an *unverified caveat* to **verified on real RK1** (`/dev/accel/accel0` on all 4 nodes).
- **Control plane NVMe:** corrected the stale "no NVMe by design" claim — all 4 nodes have a 500 GB NVMe, and the CP's is used for Longhorn (the repo's own `controlplane-patch.yaml` mounts it + `allowSchedulingOnControlPlanes`). Hardware table, topology, and storage total (1.5 TB → 2 TB) updated.
- **CHANGELOG:** `[Unreleased]` → `[1.2.1] - 2026-06-23` (the deploy/wipe/secret-template fixes #39/#40/#44–47/#49 + these doc corrections).

markdownlint passes. After merge: tag `v1.2.1` + cut the release.