### PR TITLE
chore(gitignore): ignore all kubeconfig variants in cluster-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Sensitive files
-cluster-config/kubeconfig
+cluster-config/kubeconfig*
 cluster-config/talosconfig
 cluster-config/secrets.yaml
 cluster-config/*-final.yaml


### PR DESCRIPTION
## Summary

The `.gitignore` rule `cluster-config/kubeconfig` was an exact match, so it only ignored the file named exactly `kubeconfig`. Generated credential variants like `cluster-config/kubeconfig-k3s` were left untracked and at risk of being committed.

Broadens the rule to a glob (`cluster-config/kubeconfig*`) so any kubeconfig credential under `cluster-config/` is ignored.

## Verification

```
$ git check-ignore -v cluster-config/kubeconfig cluster-config/kubeconfig-k3s
.gitignore:2:cluster-config/kubeconfig*	cluster-config/kubeconfig
.gitignore:2:cluster-config/kubeconfig*	cluster-config/kubeconfig-k3s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)