### PR TITLE
docs: link Next Steps After Deployment to tracking issues

### DIFF
--- a/CLUSTER_PLAN.md
+++ b/CLUSTER_PLAN.md
@@ -467,9 +467,9 @@ kubectl get pvc --all-namespaces         # List all PVCs
 
 ## Next Steps After Deployment
 
-1. **Install CNI** - Flannel is default, consider Cilium for advanced networking
-2. **Deploy Metrics Server** - For `kubectl top` and HPA
-3. **Set up Monitoring** - Prometheus + Grafana stack
-4. **Test Storage** - Create PVC and verify Longhorn replication
-5. **NPU Workloads** - Deploy RKNN inference containers
-6. **Backup Strategy** - Configure Longhorn backup to S3/NFS
+1. **Install CNI** - Flannel is default, consider Cilium for advanced networking (#57)
+2. **Deploy Metrics Server** - For `kubectl top` and HPA (#58)
+3. **Set up Monitoring** - Prometheus + Grafana stack (#59)
+4. **Test Storage** - Create PVC and verify Longhorn replication (#60)
+5. **NPU Workloads** - Deploy RKNN inference containers (#61)
+6. **Backup Strategy** - Configure Longhorn backup to S3/NFS (#62)


### PR DESCRIPTION
## Summary
- The `CLUSTER_PLAN.md` "Next Steps After Deployment" checklist had no GitHub issues behind it.
- Filed #57-62, one per item, and cross-referenced each line.

## Test plan
- [x] Docs-only change