### PR TITLE
feat: add Metrics Server deployment phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`deploy-talos-cluster.sh metrics-server`** (Phase 10): installs the `metrics-server` Helm chart with `--kubelet-insecure-tls`, needed because Talos kubelet serving certs carry only a DNS SAN and fail the default IP-based TLS verification. Wired into the `deploy` flow alongside the Longhorn prompt. Validated end-to-end on the 4-node hardware - `kubectl top nodes`/`kubectl top pods` return data from all 4 nodes ([#58](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/58)).
+
 ## [1.2.1] - 2026-06-23
 
 ### Fixed

--- a/CLUSTER_PLAN.md
+++ b/CLUSTER_PLAN.md
@@ -468,7 +468,7 @@ kubectl get pvc --all-namespaces         # List all PVCs
 ## Next Steps After Deployment
 
 1. **Install CNI** - Flannel is default, consider Cilium for advanced networking (#57)
-2. **Deploy Metrics Server** - For `kubectl top` and HPA (#58)
+2. **Deploy Metrics Server** - For `kubectl top` and HPA; automated via `./scripts/deploy-talos-cluster.sh metrics-server` (#58)
 3. **Set up Monitoring** - Prometheus + Grafana stack (#59)
 4. **Test Storage** - Create PVC and verify Longhorn replication (#60)
 5. **NPU Workloads** - Deploy RKNN inference containers (#61)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -26,6 +26,7 @@ Use the `deploy-talos-cluster.sh` script for automated deployment:
 | `bootstrap` | Bootstrap Kubernetes cluster |
 | `kubeconfig` | Get kubeconfig for kubectl access |
 | `longhorn` | Install Longhorn storage |
+| `metrics-server` | Install Metrics Server (`kubectl top`, HPA) |
 | `status` | Show cluster status |
 | `reset` | Reset cluster (DESTRUCTIVE!) |
 

--- a/scripts/deploy-talos-cluster.sh
+++ b/scripts/deploy-talos-cluster.sh
@@ -723,6 +723,59 @@ install_longhorn() {
 }
 
 # =============================================================================
+# Phase 10: Install Metrics Server
+# =============================================================================
+
+install_metrics_server() {
+    log_info "=== Phase 10: Installing Metrics Server ==="
+
+    cd "$CONFIG_DIR"
+    export KUBECONFIG="$CONFIG_DIR/kubeconfig"
+
+    # Check if nodes are ready
+    log_info "Checking node status..."
+    if ! kubectl get nodes &>/dev/null; then
+        log_error "Cannot access Kubernetes cluster"
+        return 1
+    fi
+
+    # Add metrics-server repo
+    log_info "Adding metrics-server Helm repository..."
+    helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+    helm repo update metrics-server
+
+    # Talos kubelet serving certs carry only a DNS SAN, not the node IP metrics-server
+    # scrapes over, so the default TLS verification fails with "doesn't contain any IP
+    # SANs" - --kubelet-insecure-tls works around that (the connection is still to the
+    # cluster's own kubelets over the private cluster network, not exposed externally).
+    if helm list -n kube-system | grep -q metrics-server; then
+        log_warn "metrics-server already installed"
+        if ! confirm "Upgrade metrics-server?"; then
+            return 0
+        fi
+        helm upgrade metrics-server metrics-server/metrics-server \
+            --namespace kube-system \
+            --set 'args={--kubelet-insecure-tls}'
+    else
+        log_info "Installing metrics-server..."
+        helm install metrics-server metrics-server/metrics-server \
+            --namespace kube-system \
+            --set 'args={--kubelet-insecure-tls}'
+    fi
+
+    # Wait for metrics-server to be ready
+    log_info "Waiting for metrics-server rollout..."
+    kubectl -n kube-system rollout status deployment/metrics-server --timeout=120s || {
+        log_warn "metrics-server not ready yet"
+    }
+
+    log_success "Metrics Server installation complete"
+    log_info "Verify with:"
+    echo "  kubectl top nodes"
+    echo "  kubectl top pods -A"
+}
+
+# =============================================================================
 # Utility Commands
 # =============================================================================
 
@@ -810,6 +863,7 @@ Commands:
   bootstrap       Bootstrap Kubernetes cluster
   kubeconfig      Get kubeconfig for kubectl access
   longhorn        Install Longhorn storage
+  metrics-server  Install Metrics Server (kubectl top, HPA)
 
   status          Show cluster status
   reset           Reset cluster (DESTRUCTIVE!)
@@ -847,6 +901,10 @@ main() {
                 if confirm "Install Longhorn storage?"; then
                     install_longhorn
                 fi
+                echo ""
+                if confirm "Install Metrics Server?"; then
+                    install_metrics_server
+                fi
             fi
             ;;
         prereq|prerequisites)
@@ -876,6 +934,9 @@ main() {
             ;;
         longhorn|storage)
             install_longhorn
+            ;;
+        metrics-server|metrics)
+            install_metrics_server
             ;;
         status)
             cluster_status


### PR DESCRIPTION
## Summary
- Adds `deploy-talos-cluster.sh metrics-server` (Phase 10): installs the `metrics-server` Helm chart with `--kubelet-insecure-tls`.
- Talos kubelet serving certs carry only a DNS SAN, so the default IP-based TLS verification metrics-server does against each kubelet's `:10250` fails with `x509: cannot validate certificate for <ip> because it doesn't contain any IP SANs`. `--kubelet-insecure-tls` works around this; the connection is still to the cluster's own kubelets over the private cluster network, not exposed externally.
- Wired into the `deploy` flow (prompt after Longhorn) and added as its own CLI subcommand, following the existing `install_longhorn` pattern.
- Closes #58.

## Test plan
- [x] `bash -n scripts/deploy-talos-cluster.sh` - syntax OK
- [x] `shellcheck scripts/deploy-talos-cluster.sh` - clean
- [x] `markdownlint-cli2` - 0 errors
- [x] Deployed live on the real 4-node cluster (10.10.88.73-76): `helm install metrics-server ...` followed by the upgrade with `--kubelet-insecure-tls`, confirmed `kubectl top nodes` and `kubectl top pods -A` both return real data from all 4 nodes. metrics-server remains installed on the cluster.