### PR TITLE
feat: add Prometheus + Grafana monitoring stack, fix Longhorn PodSecurity bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`deploy-talos-cluster.sh metrics-server`** (Phase 10): installs the `metrics-server` Helm chart with `--kubelet-insecure-tls`, needed because Talos kubelet serving certs carry only a DNS SAN and fail the default IP-based TLS verification. Wired into the `deploy` flow alongside the Longhorn prompt. Validated end-to-end on the 4-node hardware - `kubectl top nodes`/`kubectl top pods` return data from all 4 nodes ([#58](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/58)).
+- **`deploy-talos-cluster.sh monitoring`** (Phase 11): installs `kube-prometheus-stack` from `cluster-config/prometheus-values.yaml` and the Longhorn `ServiceMonitor`. Disabled the `kubeProxy` scrape target (metrics bind to `127.0.0.1` by default, unreachable from the ServiceMonitor). Validated end-to-end on the 4-node hardware - all 30 Prometheus scrape targets up, Grafana healthy with 15 pre-installed Kubernetes dashboards ([#59](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/59)).
+
+### Fixed
+
+- **`install_longhorn` / new `install_monitoring`: privileged pods rejected by the cluster's default "baseline" PodSecurity** on a freshly-created namespace - `longhorn-manager` (hostPath/privileged) and `node-exporter` (hostNetwork/hostPID) both stayed un-schedulable until their namespace was labeled `pod-security.kubernetes.io/enforce=privileged`. `docs/INSTALLATION.md`'s manual steps already did this; the scripted `install_longhorn()` path did not. Both phases now label their namespace before installing ([#65](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/65)).
 
 ## [1.2.1] - 2026-06-23
 

--- a/CLUSTER_PLAN.md
+++ b/CLUSTER_PLAN.md
@@ -469,7 +469,7 @@ kubectl get pvc --all-namespaces         # List all PVCs
 
 1. **Install CNI** - Flannel is default, consider Cilium for advanced networking (#57)
 2. **Deploy Metrics Server** - For `kubectl top` and HPA; automated via `./scripts/deploy-talos-cluster.sh metrics-server` (#58)
-3. **Set up Monitoring** - Prometheus + Grafana stack (#59)
+3. **Set up Monitoring** - Prometheus + Grafana stack; automated via `./scripts/deploy-talos-cluster.sh monitoring` (#59)
 4. **Test Storage** - Create PVC and verify Longhorn replication (#60)
 5. **NPU Workloads** - Deploy RKNN inference containers (#61)
 6. **Backup Strategy** - Configure Longhorn backup to S3/NFS (#62)

--- a/cluster-config/prometheus-values.yaml
+++ b/cluster-config/prometheus-values.yaml
@@ -74,3 +74,9 @@ kubeScheduler:
 
 kubeControllerManager:
   enabled: false
+
+# kube-proxy metrics bind to 127.0.0.1:10249 by default and aren't reachable
+# from the ServiceMonitor's pod network scrape without extra kube-proxy
+# config; disable rather than carry a permanently-down target.
+kubeProxy:
+  enabled: false

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -27,6 +27,7 @@ Use the `deploy-talos-cluster.sh` script for automated deployment:
 | `kubeconfig` | Get kubeconfig for kubectl access |
 | `longhorn` | Install Longhorn storage |
 | `metrics-server` | Install Metrics Server (`kubectl top`, HPA) |
+| `monitoring` | Install Prometheus + Grafana monitoring stack |
 | `status` | Show cluster status |
 | `reset` | Reset cluster (DESTRUCTIVE!) |
 

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -18,6 +18,10 @@ The monitoring stack includes:
 
 ## Access URLs
 
+> **Requires MetalLB + an nginx ingress controller**, neither of which is deployed by
+> `deploy-talos-cluster.sh` yet - the hostnames below won't resolve until those are in
+> place. Until then, use `kubectl -n monitoring port-forward` (see below).
+
 Add these entries to `/etc/hosts` on your workstation:
 
 ```
@@ -35,6 +39,14 @@ Add these entries to `/etc/hosts` on your workstation:
 ```bash
 kubectl --namespace monitoring get secrets prometheus-grafana \
   -o jsonpath="{.data.admin-password}" | base64 -d ; echo
+```
+
+### Access via Port-Forward (no ingress required)
+
+```bash
+kubectl -n monitoring port-forward svc/prometheus-grafana 3000:80
+kubectl -n monitoring port-forward svc/prometheus-kube-prometheus-prometheus 9090:9090
+kubectl -n monitoring port-forward svc/prometheus-kube-prometheus-alertmanager 9093:9093
 ```
 
 ---

--- a/scripts/deploy-talos-cluster.sh
+++ b/scripts/deploy-talos-cluster.sh
@@ -685,6 +685,14 @@ install_longhorn() {
     helm repo add longhorn https://charts.longhorn.io
     helm repo update
 
+    # longhorn-manager needs privileged/hostPath access; the cluster's default
+    # PodSecurity admission ("baseline") rejects it unless the namespace is
+    # explicitly labeled first. --create-namespace on a fresh install creates
+    # a bare namespace with no such label, so ensure it here regardless of
+    # whether this is a fresh install or an upgrade of an existing one.
+    kubectl create namespace longhorn-system --dry-run=client -o yaml | kubectl apply -f -
+    kubectl label namespace longhorn-system pod-security.kubernetes.io/enforce=privileged --overwrite
+
     # Check if already installed
     if helm list -n longhorn-system | grep -q longhorn; then
         log_warn "Longhorn already installed"
@@ -776,6 +784,79 @@ install_metrics_server() {
 }
 
 # =============================================================================
+# Phase 11: Install Monitoring (Prometheus + Grafana)
+# =============================================================================
+
+install_monitoring() {
+    log_info "=== Phase 11: Installing Monitoring Stack ==="
+
+    cd "$CONFIG_DIR"
+    export KUBECONFIG="$CONFIG_DIR/kubeconfig"
+
+    # Check if nodes are ready
+    log_info "Checking node status..."
+    if ! kubectl get nodes &>/dev/null; then
+        log_error "Cannot access Kubernetes cluster"
+        return 1
+    fi
+
+    if ! kubectl get storageclass longhorn &>/dev/null; then
+        log_warn "No 'longhorn' storage class found - Grafana/Prometheus/Alertmanager PVCs will stay Pending"
+        if ! confirm "Continue anyway?"; then
+            return 0
+        fi
+    fi
+
+    # Add prometheus-community repo
+    log_info "Adding prometheus-community Helm repository..."
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm repo update prometheus-community
+
+    # node-exporter needs hostNetwork/hostPID/hostPath access; the cluster's
+    # default PodSecurity admission ("baseline") rejects it unless the
+    # namespace is explicitly labeled first (same issue as longhorn-system).
+    kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
+    kubectl label namespace monitoring pod-security.kubernetes.io/enforce=privileged --overwrite
+
+    # Check if already installed
+    if helm list -n monitoring | grep -q prometheus; then
+        log_warn "Monitoring stack already installed"
+        if ! confirm "Upgrade monitoring stack?"; then
+            return 0
+        fi
+        helm upgrade prometheus prometheus-community/kube-prometheus-stack \
+            --namespace monitoring \
+            -f "$CONFIG_DIR/prometheus-values.yaml"
+    else
+        log_info "Installing kube-prometheus-stack..."
+        helm install prometheus prometheus-community/kube-prometheus-stack \
+            --namespace monitoring \
+            -f "$CONFIG_DIR/prometheus-values.yaml"
+    fi
+
+    # Wait for the stack to be ready
+    log_info "Waiting for monitoring pods to be ready..."
+    kubectl -n monitoring wait --for=condition=ready pod -l release=prometheus --timeout=300s || {
+        log_warn "Monitoring pods not ready yet"
+    }
+
+    # Longhorn metrics, if Longhorn is installed
+    if kubectl get namespace longhorn-system &>/dev/null; then
+        log_info "Adding Longhorn ServiceMonitor..."
+        kubectl apply -f "$CONFIG_DIR/longhorn-servicemonitor.yaml"
+    fi
+
+    log_success "Monitoring stack installation complete"
+    log_info "Get the Grafana admin password:"
+    echo "  kubectl -n monitoring get secrets prometheus-grafana -o jsonpath='{.data.admin-password}' | base64 -d; echo"
+    log_info "Access Grafana / Prometheus / Alertmanager:"
+    echo "  kubectl -n monitoring port-forward svc/prometheus-grafana 3000:80"
+    echo "  kubectl -n monitoring port-forward svc/prometheus-kube-prometheus-prometheus 9090:9090"
+    echo "  kubectl -n monitoring port-forward svc/prometheus-kube-prometheus-alertmanager 9093:9093"
+    log_info "See docs/MONITORING.md for ingress hostnames and dashboard details."
+}
+
+# =============================================================================
 # Utility Commands
 # =============================================================================
 
@@ -864,6 +945,7 @@ Commands:
   kubeconfig      Get kubeconfig for kubectl access
   longhorn        Install Longhorn storage
   metrics-server  Install Metrics Server (kubectl top, HPA)
+  monitoring      Install Prometheus + Grafana monitoring stack
 
   status          Show cluster status
   reset           Reset cluster (DESTRUCTIVE!)
@@ -905,6 +987,10 @@ main() {
                 if confirm "Install Metrics Server?"; then
                     install_metrics_server
                 fi
+                echo ""
+                if confirm "Install Prometheus + Grafana monitoring stack?"; then
+                    install_monitoring
+                fi
             fi
             ;;
         prereq|prerequisites)
@@ -937,6 +1023,9 @@ main() {
             ;;
         metrics-server|metrics)
             install_metrics_server
+            ;;
+        monitoring)
+            install_monitoring
             ;;
         status)
             cluster_status


### PR DESCRIPTION
## Summary
- Adds `deploy-talos-cluster.sh monitoring` (Phase 11): installs `kube-prometheus-stack` from `cluster-config/prometheus-values.yaml`, plus the existing Longhorn `ServiceMonitor` when Longhorn is present.
- Disables the `kubeProxy` scrape target in `prometheus-values.yaml` - its metrics bind to `127.0.0.1:10249` by default and aren't reachable via the ServiceMonitor's pod-network scrape, so it was a permanently-down target.
- **Bug fix (#65):** found while validating this on real hardware - both `install_longhorn` and the new monitoring phase were blocked by the cluster's default "baseline" PodSecurity admission. `longhorn-manager` (hostPath/privileged) and `node-exporter` (hostNetwork/hostPID) both stay un-schedulable on a freshly-created namespace until it's labeled `pod-security.kubernetes.io/enforce=privileged`. `docs/INSTALLATION.md`'s manual steps already knew this; the scripted path did not. Both phases now label their namespace before installing.
- Adds a caveat to `docs/MONITORING.md`: the documented `grafana.local`/`prometheus.local`/`alertmanager.local` hostnames require MetalLB + an nginx ingress controller, neither of which is deployed yet - added `kubectl port-forward` instructions as the working alternative.
- Closes #59, closes #65.

## Test plan
- [x] `bash -n` / `shellcheck` on `deploy-talos-cluster.sh` - clean
- [x] `markdownlint-cli2` - 0 errors
- [x] Deployed live on the real 4-node cluster (10.10.88.73-76):
  - Confirmed the PodSecurity bug reproduces on a fresh `longhorn-system`/`monitoring` namespace, fixed it, and re-ran both `install_longhorn` and `install_monitoring` from the actual script (not just ad hoc commands) to validate the idempotent upgrade path
  - All 30 Prometheus scrape targets up, including the 4 Longhorn `ServiceMonitor` targets
  - Grafana healthy (`/api/health`), 15 pre-installed Kubernetes dashboards present
  - `node-exporter` running on all 4 nodes