### PR TITLE
docs: record 2026-07-03 re-platform to K3s/Armbian; fix NPU-dead Armbian image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Physical cluster re-platformed from Talos to K3s on Armbian (2026-07-03)** to run
+  RKLLM NPU inference, which requires the vendor-kernel rknpu driver that Talos cannot
+  ship (see `docs/NPU-TEFLON.md` for the Talos-side analysis). All four nodes reflashed
+  to Armbian Trixie (vendor kernel `6.1.115-vendor-rk35xx`, `RKNPU driver: v0.9.8`),
+  K3s v1.36.2, [exo-rkllama](https://github.com/freed-dev-llc/exo-rkllama) `rk-v0.1.0`
+  deployed as a privileged DaemonSet. Validated: streamed chat completions from the
+  NPU (~90% load on all three cores, 3.46 tok/s generate on a w8a8_g128 3B), two
+  replicas on distinct nodes serving concurrent requests 3/3. Bring-up procedure:
+  exo-rkllama `docs/rk-hardware/RUNBOOK.md`. The Talos docs and scripts remain valid
+  for redeploying Talos; they no longer describe the running cluster
+  ([#69](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/69)).
+
 ### Added
 
 - **`deploy-talos-cluster.sh metrics-server`** (Phase 10): installs the `metrics-server` Helm chart with `--kubelet-insecure-tls`, needed because Talos kubelet serving certs carry only a DNS SAN and fail the default IP-based TLS verification. Wired into the `deploy` flow alongside the Longhorn prompt. Validated end-to-end on the 4-node hardware - `kubectl top nodes`/`kubectl top pods` return data from all 4 nodes ([#58](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/58)).
@@ -16,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docs/NPU-TEFLON.md` and `cluster-config/npu-teflon-test.yaml`**: NPU inference workload via Mesa's Teflon TFLite delegate - the RKNN/RKLLM SDK this repo also documents is K3s/Armbian-only, so on this Talos cluster the achievable path is the open `rocket` driver + Teflon. Since no distro packages Mesa's rocket/teflon support yet, the manifest builds Mesa from source (not the unofficial prebuilt binary some projects use) and runs a MobileNetV1 classification through the delegate. Validated end-to-end on the 4-node hardware - all 27 CONV/DWCONV layers `supported` (genuine NPU offload), correct classification result, reproduced from a clean pod on two different nodes ([#61](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/61)).
 
 ### Fixed
+
+- **`docs/INSTALLATION-K3S.md`: wrong Armbian image for NPU work** - the guide
+  downloaded `Bookworm_current` (mainline kernel, no rknpu driver), which reproduces
+  the Talos NPU dead-end on Armbian. It now prescribes the `vendor` kernel image
+  (`Trixie_vendor_minimal`) with the verification command, and stages the decompressed
+  image on the BMC microSD for a BMC-local flash (the remote-flash-from-/tmp pitfall
+  already documented for Talos in
+  [#44](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/44))
+  ([#69](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/69)).
 
 - **`install_longhorn` / new `install_monitoring`: privileged pods rejected by the cluster's default "baseline" PodSecurity** on a freshly-created namespace - `longhorn-manager` (hostPath/privileged) and `node-exporter` (hostNetwork/hostPID) both stayed un-schedulable until their namespace was labeled `pod-security.kubernetes.io/enforce=privileged`. `docs/INSTALLATION.md`'s manual steps already did this; the scripted `install_longhorn()` path did not. Both phases now label their namespace before installing ([#65](https://github.com/freed-dev-llc/turing-rk1-cluster/issues/65)).
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ A 4-node bare-metal Kubernetes cluster built on Turing RK1 compute modules, supp
 
 ## Choose Your Distribution
 
+> **Current deployment (2026-07-03):** the physical cluster runs **K3s on Armbian**
+> (vendor kernel 6.1.115, rknpu driver v0.9.8) to serve LLM inference from the RK3588
+> NPUs via [exo-rkllama](https://github.com/freed-dev-llc/exo-rkllama) `rk-v0.1.0`
+> (validated: streamed completions, ~90% load on all three NPU cores, data-parallel
+> routing across nodes). The Talos documentation and scripts below remain the
+> supported path for redeploying an immutable cluster; they no longer describe the
+> running hardware.
+
 | Distribution | Best For | NPU/GPU | Shell Access |
 |--------------|----------|---------|--------------|
 | **[Talos Linux](docs/INSTALLATION.md)** | Production, Security | Partial | API only |

--- a/docs/INSTALLATION-K3S.md
+++ b/docs/INSTALLATION-K3S.md
@@ -150,14 +150,21 @@ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 ### Required Images
 
-Download Armbian for Turing RK1:
+Download Armbian for Turing RK1.
+
+> **Use the `vendor` kernel image, not `current`/`edge`.** The mainline kernels have
+> no rknpu driver, so RKNN/RKLLM NPU inference cannot work on them (the same
+> limitation as stock Talos, see `docs/NPU-TEFLON.md`). The vendor (Rockchip BSP
+> 6.1) build ships rknpu; verified 2026-07-03 on all four nodes as kernel
+> `6.1.115-vendor-rk35xx` with `RKNPU driver: v0.9.8`
+> (`cat /sys/kernel/debug/rknpu/version`).
+
 ```bash
-# Official Armbian image for Turing RK1
+# Official Armbian image for Turing RK1 (vendor kernel, minimal CLI)
 # Check: https://www.armbian.com/turing-rk1/
-# Or: https://github.com/armbian/community/releases
 
 wget -O armbian-turing-rk1.img.xz \
-  "https://dl.armbian.com/turing-rk1/Bookworm_current"
+  "https://dl.armbian.com/turing-rk1/Trixie_vendor_minimal"
 ```
 
 ---
@@ -220,11 +227,11 @@ export TPI_HOSTNAME=10.10.88.70
 ### Step 1: Download Armbian Image
 
 ```bash
-# Download latest Armbian for Turing RK1
+# Download Armbian for Turing RK1 (vendor kernel; see Required Images above)
 mkdir -p images
 cd images
 wget -O armbian-turing-rk1.img.xz \
-  "https://dl.armbian.com/turing-rk1/Bookworm_current"
+  "https://dl.armbian.com/turing-rk1/Trixie_vendor_minimal"
 ```
 
 ### Step 2: Flash All Nodes
@@ -232,11 +239,16 @@ wget -O armbian-turing-rk1.img.xz \
 ```bash
 # Ensure TPI env vars are set
 
-# Flash all nodes with Armbian
-for node in 1 2 3 4; do
-  echo "Flashing node $node..."
-  tpi flash -n $node --image-path images/armbian-turing-rk1.img.xz
-done
+# Stage the decompressed image on the BMC microSD first: the BMC /tmp tmpfs
+# is ~58 MB and remote flashing of the compressed image is slower than a
+# BMC-local flash (same finding as the Talos deploy script, issue #44).
+unxz -k images/armbian-turing-rk1.img.xz
+scp images/armbian-turing-rk1.img root@$TPI_HOSTNAME:/mnt/sdcard/images/
+
+# Flash all nodes with Armbian (BMC-local)
+ssh root@$TPI_HOSTNAME 'for node in 1 2 3 4; do
+  tpi flash --local --image-path /mnt/sdcard/images/armbian-turing-rk1.img --node $node
+done'
 
 # Power on all nodes
 for node in 1 2 3 4; do


### PR DESCRIPTION
## Summary

Brings the repo docs in line with the hardware after the 2026-07-03 re-platform (details in #69):

- **README**: current-deployment note under "Choose Your Distribution": the physical cluster runs K3s on Armbian (vendor kernel, rknpu v0.9.8) serving RKLLM inference via [exo-rkllama rk-v0.1.0](https://github.com/freed-dev-llc/exo-rkllama/releases/tag/rk-v0.1.0); Talos docs/scripts remain the supported redeploy path.
- **INSTALLATION-K3S.md**: the guide downloaded `Bookworm_current`, a mainline-kernel image with no rknpu driver, which reproduces the Talos NPU dead-end. Now prescribes `Trixie_vendor_minimal` (vendor 6.1.115, driver v0.9.8, verified on all four nodes) with the verification command, and stages the decompressed image on the BMC microSD for a BMC-local flash, matching the #44 finding from the Talos deploy script.
- **CHANGELOG**: Changed + Fixed entries under [Unreleased].

markdownlint clean against the repo config.

Closes #69