### PR TITLE
feat: expose exo web UI via Traefik ingress

### DIFF
--- a/cluster-config/exo-web.yaml
+++ b/cluster-config/exo-web.yaml
@@ -1,0 +1,52 @@
+---
+# Stable cluster-wide endpoint for the exo web UI + OpenAI-compatible API.
+# exo runs as a hostNetwork DaemonSet (app.kubernetes.io/name=exo) with each
+# pod bound to :52415 on its node. This Service load-balances across all four
+# nodes; the Traefik Ingress fronts it on a single URL.
+apiVersion: v1
+kind: Service
+metadata:
+  name: exo-web
+  namespace: exo-rk
+  labels:
+    app.kubernetes.io/name: exo
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: exo
+  ports:
+    - name: api
+      port: 52415
+      targetPort: 52415
+      protocol: TCP
+---
+# Traefik Ingress. Reach it at http://exo.local/ (add exo.local -> any node IP
+# to /etc/hosts) or directly at http://<node-ip>/ via the hostless rule.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: exo-web
+  namespace: exo-rk
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: exo.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: exo-web
+                port:
+                  number: 52415
+    # Also allow access via raw node IP without a Host header.
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: exo-web
+                port:
+                  number: 52415


### PR DESCRIPTION
## What

Adds `cluster-config/exo-web.yaml`: a ClusterIP Service + Traefik Ingress that give the exo web UI and OpenAI-compatible API a single cluster endpoint.

## Why

exo runs as a `hostNetwork` DaemonSet, so its UI/API were only reachable per node at `<node-ip>:52415` with no stable endpoint. The Service load-balances `app.kubernetes.io/name=exo` across all four nodes; the Ingress fronts it via the already-running Traefik.

## Verification

Applied to the live cluster:
- Service `exo-web` has all 4 endpoints (`.73-.76:52415`).
- `http://<node-ip>/` → HTTP 200, `<title>EXO</title>` (hostless rule).
- `http://exo.local/` → HTTP 200 (add `exo.local` to /etc/hosts).
- `GET /v1/models` returns the model list through Traefik.

Non-destructive: no K3s or exo changes.