### PR TITLE
feat: self-healing exo NPU model preloader CronJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ See [docs/COMPARISON.md](docs/COMPARISON.md) for a detailed feature comparison.
 | Portainer Agent | [cluster-config/portainer-agent.yaml](cluster-config/portainer-agent.yaml) | Agent deployment |
 | Prometheus Values | [cluster-config/prometheus-values.yaml](cluster-config/prometheus-values.yaml) | Monitoring stack config |
 | External Scrape | [cluster-config/external-scrape-config.yaml](cluster-config/external-scrape-config.yaml) | Docker host monitoring |
+| exo Web UI | [cluster-config/exo-web.yaml](cluster-config/exo-web.yaml) | Cluster-wide endpoint for the exo web UI + API |
+| exo Model Preload | [cluster-config/exo-preload-cronjob.yaml](cluster-config/exo-preload-cronjob.yaml) | Self-healing NPU model preloader |
 
 ### Reference Documentation
 
@@ -242,6 +244,51 @@ Test BMC connectivity:
 ```bash
 ./scripts/wipe-cluster.sh status
 ```
+
+---
+
+## Distributed NPU Inference (exo)
+
+The cluster runs [exo-rkllama](https://github.com/freed-dev-llc/exo-rkllama) as a
+DaemonSet in the `exo-rk` namespace, serving LLM inference on each node's RK3588 NPU.
+Models are pre-converted `.rkllm` files stored on the NVMe drives; the web UI and
+OpenAI-compatible API are reachable at `http://exo.local/` (see
+[exo-web.yaml](cluster-config/exo-web.yaml)).
+
+### How instances and parallelism work
+
+A model runs as a single-node, whole-model instance: one launched instance loads the
+full model on one node's NPU. exo routes each request to the **least-loaded** instance
+and each instance processes one generation at a time, so running one instance per node
+gives N-way parallelism (four concurrent requests on the four RK1 nodes).
+
+Instance state is ephemeral. A reboot, pod restart, or image roll drops every loaded
+instance, and exo does not auto-restore them (chat requests return 404 rather than
+lazy-loading). The model files and cards survive on the NVMe; only the loaded
+instances are lost.
+
+### Example: self-healing model preloader
+
+[exo-preload-cronjob.yaml](cluster-config/exo-preload-cronjob.yaml) reconciles the
+desired state on a schedule: it ensures the target model is loaded on one instance per
+NPU node, re-launching any that are missing after a reboot. It is idempotent (a no-op
+when already fully loaded) and waits for each instance to finish loading before
+starting the next, so placement spreads them across distinct nodes.
+
+```bash
+# Deploy the preloader (defaults to model qwen2.5-14b-rkllm, one instance per node)
+kubectl apply -f cluster-config/exo-preload-cronjob.yaml
+
+# Force a reconcile now instead of waiting for the schedule
+kubectl -n exo-rk create job exo-preload-now --from=cronjob/exo-model-preload
+kubectl -n exo-rk logs -f job/exo-preload-now
+# model=qwen2.5-14b-rkllm desired=4 have=3 loaded_nodes=3
+# launch attempt 1: Command received.
+# reconcile complete: 4/4 instances of qwen2.5-14b-rkllm
+```
+
+Change the `MODEL` env in the manifest to preload a different model, or set `INSTANCES`
+to cap the count below the node total.
 
 ---
 

--- a/cluster-config/exo-preload-cronjob.yaml
+++ b/cluster-config/exo-preload-cronjob.yaml
@@ -1,0 +1,93 @@
+---
+# Self-healing preloader for exo NPU model instances.
+#
+# exo instance state is ephemeral: a node reboot, pod restart, or image roll drops
+# every loaded model instance, and exo does not auto-restore them (chat requests
+# 404 rather than lazy-load). This CronJob reconciles the desired state: it ensures
+# the target model is loaded on one instance per NPU node, giving N-way parallel
+# request handling (exo routes each request to the least-loaded instance).
+#
+# It is idempotent and cheap when healthy: if the model already has one instance per
+# node, the run is a no-op. After a reboot it re-launches the missing instances,
+# waiting for each to finish loading (node RAM committed) before starting the next so
+# placement spreads them across distinct nodes.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: exo-model-preload
+  namespace: exo-rk
+  labels:
+    app.kubernetes.io/name: exo-model-preload
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 900
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: exo-model-preload
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: preload
+              image: alpine:3.20
+              env:
+                # exo API: the in-cluster Service created by exo-web.yaml.
+                - name: EXO_API
+                  value: "http://exo-web:52415"
+                - name: MODEL
+                  value: "qwen2.5-14b-rkllm"
+                # Optional cap; defaults to the number of NPU nodes when empty.
+                - name: INSTANCES
+                  value: ""
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  apk add --no-cache curl jq >/dev/null 2>&1
+
+                  st() { curl -sf -m 10 "$EXO_API/state"; }
+                  inst_count() {
+                    st | jq --arg m "$MODEL" \
+                      '[.instances[] | .RkllmSingleNodeInstance // empty
+                        | select(.shardAssignments.modelId==$m)] | length'
+                  }
+                  # A node counts as "loaded" once >10GB of its RAM is committed.
+                  loaded_nodes() {
+                    st | jq '[.nodeMemory[]
+                      | select((.ramTotal.inBytes - .ramAvailable.inBytes) > 10e9)] | length'
+                  }
+
+                  DESIRED="${INSTANCES:-$(st | jq '.nodeIdentities | length')}"
+                  have=$(inst_count)
+                  echo "model=$MODEL desired=$DESIRED have=$have loaded_nodes=$(loaded_nodes)"
+
+                  attempt=0
+                  while [ "$have" -lt "$DESIRED" ]; do
+                    attempt=$((attempt + 1))
+                    if [ "$attempt" -gt "$((DESIRED + 2))" ]; then
+                      echo "safety stop after $attempt attempts (have=$have)"; break
+                    fi
+                    before=$(loaded_nodes)
+                    placement=$(curl -sf -m 20 \
+                      "$EXO_API/instance/placement?model_id=$MODEL&sharding=Pipeline&instance_meta=RkllmSingleNode&min_nodes=1")
+                    msg=$(curl -sf -m 30 -X POST "$EXO_API/instance" \
+                      -H 'Content-Type: application/json' \
+                      -d "$(printf '%s' "$placement" | jq -c '{instance: .}')" \
+                      | jq -r '.message // .')
+                    echo "launch attempt $attempt: $msg"
+                    # Wait for the new instance to finish loading before the next launch
+                    # so placement sees the node as used and spreads to a fresh node.
+                    for _ in $(seq 1 30); do
+                      sleep 8
+                      [ "$(loaded_nodes)" -gt "$before" ] && break
+                    done
+                    have=$(inst_count)
+                    echo "  have=$have loaded_nodes=$(loaded_nodes)"
+                  done
+                  echo "reconcile complete: $have/$DESIRED instances of $MODEL"


### PR DESCRIPTION
## What

Adds `cluster-config/exo-preload-cronjob.yaml`: a CronJob in the `exo-rk` namespace that keeps the target model loaded on one exo instance per NPU node, plus a README section documenting exo instance/parallelism behavior and a worked example.

## Why

exo instance state is ephemeral. A reboot, pod restart, or image roll drops every loaded model instance, and exo does not auto-restore them (chat requests 404 rather than lazy-load). The model files/cards survive on NVMe, but the loaded instances (and their N-way parallelism) do not. This reconciler restores them automatically.

## Behavior

- Idempotent: no-op when the model already has one instance per node.
- On a deficit, launches the missing instances via the exo placement/instance API, waiting for each to finish loading (node RAM committed, read from `/state` `nodeMemory`) before the next, so placement spreads them across distinct nodes.
- `MODEL` and `INSTANCES` are env-configurable; `INSTANCES` defaults to the NPU node count.

## Verified on the live cluster

- Healthy run: `desired=4 have=4` -> no-op.
- Recovery run: deleted one 14B instance (-> 3), triggered the job, it launched one and waited for load (`loaded_nodes 3->4`), `reconcile complete: 4/4`.
- Applied and running in `exo-rk`.