### PR TITLE
docs: reference exo-rkllama rk-v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **exo-rkllama reference bumped to `rk-v0.2.0`** in the deployment note, matching the DaemonSet pin and the deployed image (NPU-gated model catalog/search) ([#75](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/75)).
+- **exo-rkllama reference bumped to `rk-v0.2.1`** in the deployment note, matching the DaemonSet pin and the deployed image (NPU-gated model catalog/search, plus the NPU onboarding pin) ([#75](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/75), #77).
 - **`CLUSTER_PLAN.md`: reworked the "Next Steps After Deployment" list into a `Roadmap` section** - marks the metrics-server / monitoring / storage / NPU-Teflon items as shipped in v1.3.0, sets the v1.4.0 focus (K3s tooling reconciliation to match the re-platformed cluster, and RKLLM/exo-rkllama productionization), and moves Cilium (#57) and Longhorn backup (#62) to a deferred backlog.
 
 ## [1.3.0] - 2026-07-03

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A 4-node bare-metal Kubernetes cluster built on Turing RK1 compute modules, supp
 
 > **Current deployment (2026-07-03):** the physical cluster runs **K3s on Armbian**
 > (vendor kernel 6.1.115, rknpu driver v0.9.8) to serve LLM inference from the RK3588
-> NPUs via [exo-rkllama](https://github.com/freed-dev-llc/exo-rkllama) `rk-v0.2.0`
+> NPUs via [exo-rkllama](https://github.com/freed-dev-llc/exo-rkllama) `rk-v0.2.1`
 > (validated: streamed completions, ~90% load on all three NPU cores, data-parallel
 > routing across nodes). The Talos documentation and scripts below remain the
 > supported path for redeploying an immutable cluster; they no longer describe the


### PR DESCRIPTION
Bumps the deployment note and changelog to `rk-v0.2.1` (adds the NPU onboarding pin on top of the NPU-gated filtering), matching the DaemonSet pin and the rolled image.