### PR TITLE
docs: record the rk-v0.2.4 roll and the upstream event-log divergence fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **exo DaemonSet rolled to `rk-v0.2.4`; event-log divergence fixed upstream** - the
+  cluster now runs [exo-rkllama `rk-v0.2.4`](https://github.com/freed-dev-llc/exo-rkllama/releases/tag/rk-v0.2.4)
+  (bundled DeepSeek-R1-14B card, `max_tokens` enforcement on the RKLLM path, and
+  the [exo-rkllama#40](https://github.com/freed-dev-llc/exo-rkllama/pull/40)
+  stall-triggered master re-election that fixes the event-log divergence
+  documented in [#85](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/85)).
+  Validated live 2026-08-08: a staggered `rollout restart` of the DaemonSet,
+  the pattern that wedged the mesh for 35+ minutes on 2026-08-07
+  ([exo-rkllama#37](https://github.com/freed-dev-llc/exo-rkllama/issues/37)),
+  reconverged unaided to 4/4 instances 4 minutes after the rollout finished,
+  with catch-up nacks peaking at attempt 2 of the trigger threshold 8. The
+  README deployment note and exo section now name `rk-v0.2.4`, and the
+  failure-mode note scopes the delete-all-pods remedy to pre-`rk-v0.2.4`
+  images ([#86](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/86)).
 - **exo-rkllama reference bumped to `rk-v0.2.1`** in the README deployment note, matching the image deployed on the live cluster's DaemonSet (`rk-v0.2.0`: NPU-gated model catalog/search; `rk-v0.2.1`: the NPU onboarding pin) ([#75](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/75), [#77](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/77)).
 - **`CLUSTER_PLAN.md`: reworked the "Next Steps After Deployment" list into a `Roadmap` section** - marks the metrics-server / monitoring / storage / NPU-Teflon items as shipped in v1.3.0, sets the v1.4.0 focus (K3s tooling reconciliation to match the re-platformed cluster, and RKLLM/exo-rkllama productionization), and moves Cilium (#57) and Longhorn backup (#62) to a deferred backlog.
 - **Dependency bumps**: `actions/checkout` → v7.0.1 ([#82](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/82)); `actions/setup-python` → v7.0.0 ([#80](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/80), semver-major; the removed `pip-install` input was unused here); `DavidAnson/markdownlint-cli2-action` → v24.1.0 ([#79](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/79), semver-major); `github/codeql-action` init/analyze pins moved from the `v4.31.9` annotated-tag object SHA to the release commit SHA it dereferences to ([#78](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/78), [#81](https://github.com/freed-dev-llc/turing-rk1-cluster/pull/81)).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A 4-node bare-metal Kubernetes cluster built on Turing RK1 compute modules, supp
 > **Current deployment (re-platformed 2026-07-03):** the physical cluster runs
 > **K3s on Armbian** (vendor kernel 6.1.115, rknpu driver v0.9.8) to serve LLM
 > inference from the RK3588 NPUs via
-> [exo-rkllama](https://github.com/freed-dev-llc/exo-rkllama) `rk-v0.2.3`
+> [exo-rkllama](https://github.com/freed-dev-llc/exo-rkllama) `rk-v0.2.4`
 > (validated at bring-up: streamed completions, ~90% load on all three NPU
 > cores, data-parallel routing across nodes). The Talos documentation and
 > scripts below remain the supported path for redeploying an immutable cluster;
@@ -262,7 +262,12 @@ models the RKLLM engine can run (search queries the `rkllm` library), and
 `rk-v0.2.1` points the onboarding wizard's small-model option at the bundled
 `llama3.2-3b-rkllm` card on NPU hosts, and `rk-v0.2.3` returns the engine's
 installation guidance (hand-place the `.rkllm` artifact and add a model card)
-when a hub model cannot be built on an NPU host, instead of an opaque 400. See
+when a hub model cannot be built on an NPU host, instead of an opaque 400.
+`rk-v0.2.4` bundles the `deepseek-r1-distill-qwen-14b-rkllm` card, enforces
+`max_tokens` on the RKLLM path (finish reason `length`), and re-elects the
+master when a pod's event-log sync stalls, fixing the staggered-restart
+divergence noted in [the preloader section](#example-self-healing-model-preloader)
+below. See
 the [exo-rkllama releases](https://github.com/freed-dev-llc/exo-rkllama/releases)
 for per-version details.
 
@@ -312,11 +317,17 @@ advanced again). Recover the node or force-delete the stuck pod
 a manual job (command above); recreate the CronJob if scheduled runs still do
 not resume.
 
-A second failure mode lives in exo itself: pods restarted at different times
-can diverge their replicated event logs permanently. Symptoms: pod logs loop
-`Nack attempt N: Requesting Event Log`, launches return "Command received."
-but no instance ever appears, and `nodeIdentities` differs per pod. Restart
-all exo pods in one command
+A second failure mode lived in exo itself, fixed since `rk-v0.2.4`: pods
+restarted at different times could diverge their replicated event logs
+permanently. Symptoms: pod logs loop `Nack attempt N: Requesting Event Log`,
+launches return "Command received." but no instance ever appears, and
+`nodeIdentities` differs per pod. Since
+[exo-rkllama#40](https://github.com/freed-dev-llc/exo-rkllama/pull/40) a
+stalled router triggers a master re-election and the mesh reconverges unaided;
+validated 2026-08-08 with a staggered `rollout restart` of the DaemonSet (the
+pattern that previously wedged the mesh): 4/4 instances were back 4 minutes
+after the rollout finished, catch-up nacks peaking at attempt 2. On images
+before `rk-v0.2.4`, restart all exo pods in one command
 (`kubectl -n exo-rk delete pods -l app.kubernetes.io/name=exo`) so they
 rejoin on one aligned epoch, then let the preloader reload; details in
 [exo-rkllama#37](https://github.com/freed-dev-llc/exo-rkllama/issues/37).


### PR DESCRIPTION
The cluster DaemonSet was rolled to [exo-rkllama rk-v0.2.4](https://github.com/freed-dev-llc/exo-rkllama/releases/tag/rk-v0.2.4) (bundled DeepSeek-R1-14B card, `max_tokens` enforcement on the RKLLM path, and the [exo-rkllama#40](https://github.com/freed-dev-llc/exo-rkllama/pull/40) stall-triggered master re-election fixing [exo-rkllama#37](https://github.com/freed-dev-llc/exo-rkllama/issues/37), the event-log divergence documented in #85).

Validation on the live cluster (2026-08-08): a staggered `rollout restart` of the DaemonSet, the pattern that wedged the mesh for 35+ minutes on 2026-08-07, reconverged unaided to 4/4 instances 4 minutes after the rollout finished; catch-up nacks peaked at attempt 2 (trigger threshold 8), confirming the detector stays silent during healthy catch-up. Streamed R1-14B inference smoke-tested after the roll.

Docs updated accordingly: README deployment note and exo version paragraph name `rk-v0.2.4`, the preloader failure-mode note scopes the delete-all-pods remedy to pre-`rk-v0.2.4` images, and the changelog records the roll with the validation figures.